### PR TITLE
Improve umilib

### DIFF
--- a/examples/ebrick-cpu-verif/cpp/driver.cc
+++ b/examples/ebrick-cpu-verif/cpp/driver.cc
@@ -29,7 +29,7 @@ void init() {
 bool gpio_write(const uint32_t data) {
     // form the UMI packet
     sb_packet p;
-    umi_pack((uint32_t*)p.data, UMI_WRITE_NORMAL, 0, 0, data);
+    umi_pack((uint32_t*)p.data, UMI_WRITE_NORMAL, 2, 0, 0, 0, (uint8_t*)(&data), 4);
 
     // send the packet
     return tx_tb.send(p);
@@ -91,7 +91,8 @@ int main(int argc, char* argv[]) {
             uint32_t opcode, size, user;
             uint64_t dstaddr, srcaddr;
             uint32_t data_arr[4];
-            umi_unpack((uint32_t*)p.data, opcode, size, user, dstaddr, srcaddr, data_arr);
+            umi_unpack((uint32_t*)p.data, opcode, size, user,
+                dstaddr, srcaddr, (uint8_t*)data_arr, 16);
 
             // handle the packet
             if (opcode == UMI_WRITE_NORMAL) {
@@ -117,7 +118,8 @@ int main(int argc, char* argv[]) {
             } else if (opcode == UMI_READ) {
                 // try to send a read response
                 sb_packet resp;
-                umi_pack((uint32_t*)resp.data, UMI_WRITE_RESPONSE, srcaddr, 0, sram[dstaddr>>2]);
+                umi_pack((uint32_t*)resp.data, UMI_WRITE_RESPONSE, 2, 0, srcaddr, 0,
+                    (uint8_t*)(&sram[dstaddr>>2]), 4);
                 if (tx1.send(resp)) {
                     // ACK if the response was sent successfully
                     rx1.recv();

--- a/examples/riscv-grid/cpp/client.cc
+++ b/examples/riscv-grid/cpp/client.cc
@@ -34,7 +34,7 @@ void dut_send(const uint32_t data, const uint32_t addr, const uint32_t row, cons
 
     // form the UMI packet
     sb_packet p;
-    umi_pack((uint32_t*)p.data, UMI_WRITE_NORMAL, dstaddr, 0, data);
+    umi_pack((uint32_t*)p.data, UMI_WRITE_NORMAL, 2, 0, dstaddr, 0, (uint8_t*)(&data), 4);
     p.destination = ((row & 0xf) << 8) | (col & 0xf);
     p.last = true;
 
@@ -51,7 +51,7 @@ void dut_recv(uint32_t& data, uint32_t& addr){
     uint32_t opcode, size, user;
     uint64_t dstaddr, srcaddr;
     uint32_t data_arr[4];
-    umi_unpack((uint32_t*)p.data, opcode, size, user, dstaddr, srcaddr, data_arr);
+    umi_unpack((uint32_t*)p.data, opcode, size, user, dstaddr, srcaddr, (uint8_t*)data_arr, 16);
 
     // only the lowest 32 bits of data and address are used
     data = data_arr[0];

--- a/examples/umiram/cpp/client.cc
+++ b/examples/umiram/cpp/client.cc
@@ -5,7 +5,7 @@ void print_packet_details(const uint32_t* p) {
     uint32_t opcode, size, user;
     uint64_t dstaddr, srcaddr;
     uint32_t data_arr[4];
-    umi_unpack(p, opcode, size, user, dstaddr, srcaddr, data_arr);
+    umi_unpack(p, opcode, size, user, dstaddr, srcaddr, (uint8_t*)data_arr, 16);
 
     // print details
     printf("opcode:  %s\n", umi_opcode_to_str(opcode).c_str());
@@ -27,14 +27,15 @@ int main() {
     sb_packet p;
 
     // write 0xBEEFCAFE to address 0x12
-    umi_pack((uint32_t*)p.data, UMI_WRITE_NORMAL, 0x12, 0, (uint32_t)0xBEEFCAFE);
+    uint32_t val = 0xBEEFCAFE;
+    umi_pack((uint32_t*)p.data, UMI_WRITE_NORMAL, 2, 0, 0x12, 0, (uint8_t*)(&val), 4);
     tx.send_blocking(p);
     printf("TX packet: %s\n", umi_packet_to_str((uint32_t*)p.data).c_str());
     print_packet_details((uint32_t*)p.data);
     printf("\n");
 
     // send request to read address 0x12 into address 0x34
-    umi_pack((uint32_t*)p.data, UMI_READ, 0x12, 0x34, (uint32_t)0);
+    umi_pack((uint32_t*)p.data, UMI_READ, 2, 0, 0x12, 0x34, NULL, 0);
     tx.send_blocking(p);
     printf("TX packet: %s\n", umi_packet_to_str((uint32_t*)p.data).c_str());
     print_packet_details((uint32_t*)p.data);


### PR DESCRIPTION
This PR improves `umilib` by making support of bursts and atomics more complete, and it also fixes a usability issue with `umi_pack` and `umi_unpack` that was making it hard to pass in generic data buffers.