### PR TITLE
Update umiram example

### DIFF
--- a/examples/umiram/cpp/client.cc
+++ b/examples/umiram/cpp/client.cc
@@ -23,6 +23,10 @@ int main() {
     SBRX rx;
     rx.init("queue-5556");
 
+    // initialize tx connection
+    SBTX stop;
+    stop.init("queue-5557");
+
     // packet structure used for sending/receiving
     sb_packet p;
 
@@ -45,6 +49,9 @@ int main() {
     rx.recv_blocking(p);
     printf("RX packet: %s\n", umi_packet_to_str((uint32_t*)p.data).c_str());
     print_packet_details((uint32_t*)p.data);
+
+    // stop simulation
+    stop.send_blocking(p);
 
     return 0;
 }

--- a/examples/umiram/scripts/test.py
+++ b/examples/umiram/scripts/test.py
@@ -22,28 +22,32 @@ def main():
     args = parser.parse_args()
 
     # clean up old queues if present
-    for port in [5555, 5556]:
+    for port in [5555, 5556, 5557]:
         filename = str(SHMEM_DIR / f'queue-{port}')
         try:
             os.remove(filename)
         except OSError:
             pass
 
-    # start chip simulation
-    start_chip()
+    chip = start_chip()
 
-    # wait for client to complete
     client = start_client()
     client.wait()
 
-def start_chip():
+    chip.wait()
+
+def start_chip(trace=True):
     cmd = []
     cmd += [EXAMPLE_DIR / 'verilator' / 'obj_dir' / 'Vtestbench']
+    if trace:
+        cmd += ['+trace']
     cmd = [str(elem) for elem in cmd]
 
     p = subprocess.Popen(cmd)
 
     atexit.register(p.terminate)
+
+    return p
 
 def start_client():
     cmd = []
@@ -51,6 +55,9 @@ def start_client():
     cmd = [str(elem) for elem in cmd]
 
     p = subprocess.Popen(cmd)
+
+    atexit.register(p.terminate)
+
     return p
 
 if __name__ == '__main__':

--- a/examples/umiram/verilator/Makefile
+++ b/examples/umiram/verilator/Makefile
@@ -13,6 +13,7 @@ obj_dir/Vtestbench:
 		--cc \
 		--exe \
 		-sv \
+		--trace \
 		--top-module testbench \
 		-I../../../verilog/sim \
 		-CFLAGS "-Wno-unknown-warning-option -I../../../../cpp" \

--- a/examples/umiram/verilator/testbench.cc
+++ b/examples/umiram/verilator/testbench.cc
@@ -1,24 +1,69 @@
-#include <cstdio>
-#include <iostream>
-#include <thread>
+// For std::unique_ptr
+#include <memory>
 
+// Include common routines
+#include <verilated.h>
+
+// Include model header, generated from Verilating "top.v"
 #include "Vtestbench.h"
-#include "verilated.h"
 
-int main(int argc, char **argv, char **env)
-{
-        Verilated::commandArgs(argc, argv);
-        Vtestbench *top = new Vtestbench;
+// Legacy function required only so linking works on Cygwin and MSVC++
+double sc_time_stamp() { return 0; }
 
-        // main loop
-        top->clk = 0;
+int main(int argc, char** argv, char** env) {
+    // Prevent unused variable warnings
+    if (false && argc && argv && env) {}
+
+    // Using unique_ptr is similar to
+    // "VerilatedContext* contextp = new VerilatedContext" then deleting at end.
+    const std::unique_ptr<VerilatedContext> contextp{new VerilatedContext};
+    // Do not instead make Vtop as a file-scope static variable, as the
+    // "C++ static initialization order fiasco" may cause a crash
+
+    // Verilator must compute traced signals
+    contextp->traceEverOn(true);
+
+    // Pass arguments so Verilated code can see them, e.g. $value$plusargs
+    // This needs to be called before you create any model
+    contextp->commandArgs(argc, argv);
+
+    // Construct the Verilated model, from Vtop.h generated from Verilating "top.v".
+    // Using unique_ptr is similar to "Vtop* top = new Vtop" then deleting at end.
+    // "TOP" will be the hierarchical name of the module.
+    const std::unique_ptr<Vtestbench> top{new Vtestbench{contextp.get(), "TOP"}};
+
+    // Set Vtestbench's input signals
+    top->clk = 0;
+    top->eval();
+
+    while (!contextp->gotFinish()) {
+        // Historical note, before Verilator 4.200 Verilated::gotFinish()
+        // was used above in place of contextp->gotFinish().
+        // Most of the contextp-> calls can use Verilated:: calls instead;
+        // the Verilated:: versions just assume there's a single context
+        // being used (per thread).  It's faster and clearer to use the
+        // newer contextp-> versions.
+
+        contextp->timeInc(1);  // 1 timeprecision period passes...
+        // Historical note, before Verilator 4.200 a sc_time_stamp()
+        // function was required instead of using timeInc.  Once timeInc()
+        // is called (with non-zero), the Verilated libraries assume the
+        // new API, and sc_time_stamp() will no longer work.
+
+        // Toggle a fast (time/2 period) clock
+        top->clk = !top->clk;
+
+        // Evaluate model
+        // (If you have multiple models being simulated in the same
+        // timestep then instead of eval(), call eval_step() on each, then
+        // eval_end_step() on each. See the manual.)
         top->eval();
-        while (!Verilated::gotFinish()) {
-                // update logic
-                top->clk ^= 1;
-                top->eval();
-        }
+    }
 
-        delete top;
-        exit(0);
+    // Final model cleanup
+    top->final();
+
+    // Return good completion status
+    // Don't use exit() or destructor won't get called
+    return 0;
 }

--- a/examples/umiram/verilog/testbench.sv
+++ b/examples/umiram/verilog/testbench.sv
@@ -27,6 +27,14 @@ module testbench (
 		.valid(umi_tx_valid) // input
 	);
 
+	wire stop_valid;
+	umi_rx_sim stop_i (
+		.clk(clk),
+		.packet(),
+		.ready(1'b1),
+		.valid(stop_valid)
+	);
+
 	// instantiate module with UMI ports
 
 	umiram ram_i (
@@ -38,9 +46,23 @@ module testbench (
 
 	initial begin
 		/* verilator lint_off IGNOREDRETURN */
-		rx_i.init($sformatf("queue-%0d", 5555));
-		tx_i.init($sformatf("queue-%0d", 5556));
+		rx_i.init("queue-5555");
+		tx_i.init("queue-5556");
+		stop_i.init("queue-5557");
 		/* verilator lint_on IGNOREDRETURN */
 	end
+
+    // VCD
+    initial begin
+        $dumpfile("testbench.vcd");
+        $dumpvars(0, testbench);
+    end
+
+    // $finish
+    always @(posedge clk) begin
+        if (stop_valid) begin
+            $finish;
+        end
+    end
 
 endmodule


### PR DESCRIPTION
This PR makes two updates to the umiram example:
* Adds VCD tracing using the "new" Verilator style (`$dumpfile`/`$dumpvars`)
* Causes Verilator to exit via `$finish`, rather than simply terminating the Verilator simulation.  I found that Verilator did not dump waveforms properly unless it exits via `$finish`, so I will start adopting this in other testbenches.  The way I implemented this feature was by adding another UMI channel, where a write to that channel is interpreted as a request to `$finish`.