### PR TITLE
Add adaptive sampling rate to performance measurement block

### DIFF
--- a/examples/riscv-grid/verilog/testbench.sv
+++ b/examples/riscv-grid/verilog/testbench.sv
@@ -71,7 +71,7 @@ module testbench (
 			tx_port = 5556;
 		end
 		if (!$value$plusargs("cycles_per_meas=%d", cycles_per_meas)) begin
-			cycles_per_meas = 1000000;
+			cycles_per_meas = 1;
 		end
 
 		/* verilator lint_off IGNOREDRETURN */


### PR DESCRIPTION
This small PR adds a feature to the performance measurement block, `perf_meas_sim`, that enables it to adapt its sampling rate so that the simulation speed is printed out approximately once a second.  This makes it easier to use `perf_meas_sim`, since users can simply instantiate the block and call `init(1)` at runtime, and the block will take care of the rest.  (Before, it was necessary to tune the argument to `init` to get a reasonable update rate).