### PR TITLE
Increase size of PCIe BAR mapping

### DIFF
--- a/cpp/switchboard_pcie.hpp
+++ b/cpp/switchboard_pcie.hpp
@@ -27,6 +27,9 @@
 
 #define REG_QUEUE_ADDR_SIZE   0x100 // size of addr space dedicated to each queue
 
+// Map enough space to configure 256 queues + global config.
+#define PCIE_BAR_MAP_SIZE (REG_QUEUE_ADDR_SIZE * 256 + REG_ENABLE)
+
 template<typename T>
 static inline void sb_pcie_deinit(T *s) {
 
@@ -45,7 +48,7 @@ class SB_pcie {
 
         virtual bool init_host(const char *uri, const char *bdf, int bar_num, void *handle) {
             m_addr = pagemap_virt_to_phys(handle);
-            m_map = (char *) pcie_bar_map(bdf, bar_num, 0, getpagesize());
+            m_map = (char *) pcie_bar_map(bdf, bar_num, 0, PCIE_BAR_MAP_SIZE);
             if (m_map == MAP_FAILED) {
                 m_map = NULL;
                 return false;
@@ -55,7 +58,7 @@ class SB_pcie {
 
         virtual void deinit_host(void) {
             if (m_map) {
-                pcie_bar_unmap(m_map, getpagesize());
+                pcie_bar_unmap(m_map, PCIE_BAR_MAP_SIZE);
             }
         }
 
@@ -101,18 +104,21 @@ class SB_pcie {
         virtual uint32_t dev_read32(uint64_t offset)
         {
                 assert(m_map);
+                assert(offset <= PCIE_BAR_MAP_SIZE - 4);
                 return pcie_read32(m_map + offset);
         }
 
         virtual void dev_write32(uint64_t offset, uint32_t v)
         {
                 assert(m_map);
+                assert(offset <= PCIE_BAR_MAP_SIZE - 4);
                 pcie_write32(m_map + offset, v);
         }
 
         virtual void dev_write32_strong(uint64_t offset, uint32_t v)
         {
                 assert(m_map);
+                assert(offset <= PCIE_BAR_MAP_SIZE - 4);
                 pcie_write32_strong(m_map + offset, v);
         }
 


### PR DESCRIPTION
Need more than a single page to accomodate bitstreams that have multiple chiplets and therefore many queues.