### PR TITLE
Change FPGA queue indexing scheme

### DIFF
--- a/verilog/fpga/sb_fpga_queues.sv
+++ b/verilog/fpga/sb_fpga_queues.sv
@@ -123,9 +123,6 @@ module sb_fpga_queues #(
     wire [NUM_QUEUES-1:0] axi_rvalid;
     wire [NUM_QUEUES-1:0] axi_rready;
 
-    assign axi_awid = 'd0;
-    assign axi_arid = 'd0;
-
     genvar i;
     generate
         for (i = 0; i < NUM_RX_QUEUES; i = i + 1) begin

--- a/verilog/fpga/umi_fpga_queues.sv
+++ b/verilog/fpga/umi_fpga_queues.sv
@@ -96,7 +96,7 @@ module umi_fpga_queues #(
         .tx_data(tx_packet),
         .tx_dest(tx_dest),
         // TODO: support burst mode
-        .tx_last(3'b1),
+        .tx_last({NUM_TX_QUEUES{1'b1}}),
         .tx_ready(tx_ready),
         .tx_valid(tx_valid),
 


### PR DESCRIPTION
Previously the queues were indexed with all RX queues enumerated first,
followed by TX queues. However, since we group queues in pairs for our
current use case, it makes more sense for us to alternate RX/TX pairs.
The new indexing scheme is:

0: 1st RX
1: 1st TX
2: 2nd RX
3: 2nd TX

etc...

This PR also includes some minor RTL lint fixes.