### PR TITLE
Provide FPGA version numbers as per-field defines

### DIFF
--- a/verilog/fpga/README.md
+++ b/verilog/fpga/README.md
@@ -20,7 +20,7 @@ accessed over an AXI-Lite interface.
 
 | **Address** | **Description** |
 |-------------|-----------------|
-| `0x00`       | Version/ID. Currently returns 0x1234_0000. (Read-only) |
+| `0x00`       | Version/ID. Split into bitfields for ID [31:16], major version [15:9], and minor version [8:0]. (Read-only) |
 | `0x04`       | Capability. Currently returns all zeros. (Read-only) |
 | `0x08`       | Clock divider. Used to program a clock divider that may be implemented at a design top-level. The effective clock speed becomes the value set in this register plus 1 (e.g. a value of 0 means no change in speed, a value of 2 means run at one third the speed). |
 

--- a/verilog/fpga/config_registers.sv
+++ b/verilog/fpga/config_registers.sv
@@ -1,5 +1,13 @@
 `default_nettype none
 
+`ifndef VERSION_MAJOR
+`define VERSION_MAJOR 0
+`endif
+
+`ifndef VERSION_MINOR
+`define VERSION_MINOR 0
+`endif
+
 module config_registers #(
    parameter NUM_QUEUES = 2
 ) (
@@ -34,7 +42,7 @@ module config_registers #(
 
     `include "sb_queue_regmap.vh"
 
-    localparam [31:0] ID_VERSION = 32'h1234_0000;
+    localparam [31:0] ID_VERSION = {16'h1234, 7'd`VERSION_MAJOR, 9'd`VERSION_MINOR};
     localparam [31:0] UNIMPLEMENTED_REG_VALUE = 32'hffff_ffff;
 
     wire axil_awvalid_q;


### PR DESCRIPTION
This PR updates the `config_registers` module to set the version number based on pre-processor macros, rather than hardcoding it to zero. I decided to split the version field into several subfields matching software-style semantic versioning, although I'm not sure if that's particularly common to do with hardware. I'm also considering whether the ID and version should be separated out to provide more bits for the version field. Let me know if you have any feedback on this!

This was tested by building an AFI with these changes included and verifying that the debug printout when initializing FPGA-based queues reflected the supplied version number:

```
$ ./fpga/fpgad/fpgad --slot 0 --rx0 myqueue
SB pcie ID=12340001
SB pcie CAP=0
Read reset state
SB QUEUE_ADDR=1e7cc6a000
SB CAPACITY=62
```