### PR TITLE
Add Python linting SB-282

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,6 @@
+[flake8]
+extend-exclude = deps,build
+max-line-length = 100
+ignore =
+    E128,
+    E125

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,37 @@
+# modified from https://github.com/siliconcompiler/siliconcompiler/blob/main/.github/workflows/lint.yml
+
+name: Lint
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  lint_python:
+    name: Lint Python Code
+
+    strategy:
+        fail-fast: false
+        matrix:
+          version:
+            - {python: "3.10", os: "ubuntu-latest"}
+
+    runs-on: ${{ matrix.version.os }}
+
+    steps:
+        - name: Check out Git repository
+          uses: actions/checkout@v3
+
+        - name: Set up Python ${{ matrix.version.python }}
+          uses: actions/setup-python@v3
+          with:
+            python-version: ${{ matrix.version.python }}
+
+        - name: Install Requirements
+          run: |
+            python3 -m pip install flake8
+
+        - name: Lint with Flake8
+          run: flake8 --statistics .

--- a/examples/minimal-icarus/scripts/test.py
+++ b/examples/minimal-icarus/scripts/test.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python3
 
 import os
-import platform
 import atexit
 import subprocess
-import argparse
 import time
 
 from pathlib import Path
@@ -13,10 +11,8 @@ THIS_DIR = Path(__file__).resolve().parent
 EXAMPLE_DIR = THIS_DIR.parent
 SHMEM_DIR = EXAMPLE_DIR
 
-def main():
-    parser = argparse.ArgumentParser()
-    args = parser.parse_args()
 
+def main():
     # clean up old queues if present
     for port in [5555, 5556]:
         filename = str(SHMEM_DIR / f'queue-{port}')
@@ -35,6 +31,7 @@ def main():
     client.wait()
     chip.wait()
 
+
 def start_chip():
     cmd = []
     cmd += ['vvp']
@@ -50,6 +47,7 @@ def start_chip():
 
     return p
 
+
 def start_client():
     cmd = []
     cmd += [EXAMPLE_DIR / 'cpp' / 'client']
@@ -60,6 +58,7 @@ def start_client():
     atexit.register(p.terminate)
 
     return p
+
 
 if __name__ == '__main__':
     main()

--- a/examples/minimal/scripts/test.py
+++ b/examples/minimal/scripts/test.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python3
 
 import os
-import platform
 import atexit
 import subprocess
-import argparse
 import time
 
 from pathlib import Path
@@ -13,10 +11,8 @@ THIS_DIR = Path(__file__).resolve().parent
 EXAMPLE_DIR = THIS_DIR.parent
 SHMEM_DIR = EXAMPLE_DIR
 
-def main():
-    parser = argparse.ArgumentParser()
-    args = parser.parse_args()
 
+def main():
     # clean up old queues if present
     for port in [5555, 5556]:
         filename = str(SHMEM_DIR / f'queue-{port}')
@@ -35,6 +31,7 @@ def main():
     client.wait()
     chip.wait()
 
+
 def start_chip():
     cmd = []
     cmd += [EXAMPLE_DIR / 'verilator' / 'obj_dir' / 'Vtestbench']
@@ -47,6 +44,7 @@ def start_chip():
 
     return p
 
+
 def start_client():
     cmd = []
     cmd += [EXAMPLE_DIR / 'cpp' / 'client']
@@ -57,6 +55,7 @@ def start_client():
     atexit.register(p.terminate)
 
     return p
+
 
 if __name__ == '__main__':
     main()

--- a/examples/python/scripts/test.py
+++ b/examples/python/scripts/test.py
@@ -10,6 +10,7 @@ import numpy as np
 from pathlib import Path
 from switchboard import delete_queue, PySbPacket, PySbTx, PySbRx
 
+
 def main():
     # clean up old queues if present
     for q in ['queue-5555', 'queue-5556']:
@@ -30,7 +31,7 @@ def main():
     txp = PySbPacket(
         destination=123456789,
         flags=1,
-        data=np.array([i&0xff for i in range(32)], dtype=np.uint8)
+        data=np.array([(i & 0xff) for i in range(32)], dtype=np.uint8)
     )
 
     # send the packet
@@ -48,7 +49,7 @@ def main():
     print(rxp)
     print()
 
-    # check that the received data 
+    # check that the received data
 
     success = (rxp.data == (txp.data + 1)).all()
 
@@ -66,6 +67,7 @@ def main():
         print("FAIL")
         sys.exit(1)
 
+
 def start_chip():
     this_dir = Path(__file__).resolve().parent
     example_dir = this_dir.parent
@@ -80,6 +82,7 @@ def start_chip():
     atexit.register(p.terminate)
 
     return p
+
 
 if __name__ == '__main__':
     main()

--- a/examples/riscv-grid/scripts/grid.py
+++ b/examples/riscv-grid/scripts/grid.py
@@ -2,7 +2,6 @@
 
 import os
 import time
-import platform
 import atexit
 import subprocess
 import argparse
@@ -17,8 +16,10 @@ TOP_DIR = EXAMPLE_DIR.parent.parent
 # figure out where shared memory queues are located
 SHMEM_DIR = EXAMPLE_DIR
 
+
 def rc2id(r, c):
     return ((r & 0xf) << 8) | (c & 0xf)
+
 
 def main():
     parser = argparse.ArgumentParser()
@@ -88,16 +89,16 @@ def main():
 
     # start router (note the flipped connections)
     start_router(
-        rx = all_tx,
-        tx = all_rx,
-        route = routing_table,
+        rx=all_tx,
+        tx=all_rx,
+        route=routing_table,
         verbose=args.verbose
     )
 
     # start chips and client
     for row in range(args.rows):
         for col in range(args.cols):
-            if (row==0) and (col==0):
+            if (row == 0) and (col == 0):
                 # client goes here
                 continue
             else:
@@ -114,8 +115,8 @@ def main():
         cols=args.cols,
         rx_port=rx_connections[0][0],
         tx_port=tx_connections[0][0],
-        bin = Path(args.binfile).resolve(),
-        params = args.params,
+        bin=Path(args.binfile).resolve(),
+        params=args.params,
         verbose=args.verbose
     )
 
@@ -126,13 +127,14 @@ def main():
     if args.extra_time is not None:
         time.sleep(args.extra_time)
 
+
 def start_chip(rx_port, tx_port, yield_every=None, vcd=False, verbose=False):
     cmd = []
     cmd += [EXAMPLE_DIR / 'verilator' / 'obj_dir' / 'Vtestbench']
     cmd += [f'+rx_port={rx_port}']
     cmd += [f'+tx_port={tx_port}']
     if vcd:
-        cmd += [f'+vcd']
+        cmd += ['+vcd']
     if yield_every is not None:
         cmd += [f'+yield_every={yield_every}']
     cmd = [str(elem) for elem in cmd]
@@ -149,6 +151,7 @@ def start_chip(rx_port, tx_port, yield_every=None, vcd=False, verbose=False):
 
     atexit.register(p.terminate)
 
+
 def start_router(rx, tx, route, verbose=False):
     cmd = []
     cmd += [TOP_DIR / 'cpp' / 'router']
@@ -161,8 +164,9 @@ def start_router(rx, tx, route, verbose=False):
         print(' '.join(cmd))
 
     p = subprocess.Popen(cmd)
-    
+
     atexit.register(p.terminate)
+
 
 def start_client(rows, cols, rx_port, tx_port, bin, params=None, verbose=False):
     cmd = []
@@ -177,6 +181,7 @@ def start_client(rows, cols, rx_port, tx_port, bin, params=None, verbose=False):
 
     p = subprocess.Popen(cmd)
     return p
+
 
 if __name__ == '__main__':
     main()

--- a/examples/router/scripts/test.py
+++ b/examples/router/scripts/test.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python3
 
 import os
-import platform
 import atexit
 import subprocess
-import argparse
 
 from pathlib import Path
 
@@ -13,10 +11,8 @@ EXAMPLE_DIR = THIS_DIR.parent
 TOP_DIR = EXAMPLE_DIR.parent.parent
 SHMEM_DIR = EXAMPLE_DIR
 
-def main():
-    parser = argparse.ArgumentParser()
-    args = parser.parse_args()
 
+def main():
     # clean up old queues if present
     for port in [5555, 5556, 5557, 5558]:
         filename = str(SHMEM_DIR / f'queue-{port}')
@@ -35,6 +31,7 @@ def main():
     client = start_client()
     client.wait()
 
+
 def start_chip():
     cmd = []
     cmd += [EXAMPLE_DIR / 'verilator' / 'obj_dir' / 'Vtestbench']
@@ -43,6 +40,7 @@ def start_chip():
     p = subprocess.Popen(cmd)
 
     atexit.register(p.terminate)
+
 
 def start_router():
     cmd = []
@@ -56,6 +54,7 @@ def start_router():
 
     atexit.register(p.terminate)
 
+
 def start_client():
     cmd = []
     cmd += [EXAMPLE_DIR / 'cpp' / 'client']
@@ -63,6 +62,7 @@ def start_client():
 
     p = subprocess.Popen(cmd)
     return p
+
 
 if __name__ == '__main__':
     main()

--- a/examples/stream/scripts/test.py
+++ b/examples/stream/scripts/test.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python3
 
 import os
-import platform
 import atexit
 import subprocess
-import argparse
 import time
 
 from pathlib import Path
@@ -13,10 +11,8 @@ THIS_DIR = Path(__file__).resolve().parent
 EXAMPLE_DIR = THIS_DIR.parent
 SHMEM_DIR = EXAMPLE_DIR
 
-def main():
-    parser = argparse.ArgumentParser()
-    args = parser.parse_args()
 
+def main():
     # clean up old queues if present
     for port in [5555, 5556]:
         filename = str(SHMEM_DIR / f'queue-{port}')
@@ -35,6 +31,7 @@ def main():
     client.wait()
     chip.wait()
 
+
 def start_chip():
     cmd = []
     cmd += [EXAMPLE_DIR / 'verilator' / 'obj_dir' / 'Vtestbench']
@@ -47,6 +44,7 @@ def start_chip():
 
     return p
 
+
 def start_client():
     cmd = []
     cmd += [EXAMPLE_DIR / 'cpp' / 'client']
@@ -57,6 +55,7 @@ def start_client():
     atexit.register(p.terminate)
 
     return p
+
 
 if __name__ == '__main__':
     main()

--- a/examples/tcp/test.py
+++ b/examples/tcp/test.py
@@ -9,6 +9,7 @@ import subprocess
 import numpy as np
 from switchboard import delete_queue, PySbPacket, PySbTx, PySbRx
 
+
 def main():
     # clean up old queues if present
     for q in ['queue-5555', 'queue-5556']:
@@ -30,7 +31,7 @@ def main():
     txp = PySbPacket(
         destination=123456789,
         flags=1,
-        data=np.array([i&0xff for i in range(32)], dtype=np.uint8)
+        data=np.array([(i & 0xff) for i in range(32)], dtype=np.uint8)
     )
 
     # send the packet
@@ -48,7 +49,7 @@ def main():
     print(rxp)
     print()
 
-    # check that the received data 
+    # check that the received data
 
     success = (rxp.data == txp.data).all()
 
@@ -60,6 +61,7 @@ def main():
     else:
         print("FAIL")
         sys.exit(1)
+
 
 def start_tcp_bridge(mode, tx=None, rx=None, host=None, port=None, quiet=True):
     cmd = []
@@ -83,6 +85,7 @@ def start_tcp_bridge(mode, tx=None, rx=None, host=None, port=None, quiet=True):
     atexit.register(p.terminate)
 
     return p
+
 
 if __name__ == '__main__':
     main()

--- a/examples/umiram/scripts/test.py
+++ b/examples/umiram/scripts/test.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python3
 
 import os
-import platform
 import atexit
 import subprocess
-import argparse
 
 from pathlib import Path
 
@@ -12,10 +10,8 @@ THIS_DIR = Path(__file__).resolve().parent
 EXAMPLE_DIR = THIS_DIR.parent
 SHMEM_DIR = EXAMPLE_DIR
 
-def main():
-    parser = argparse.ArgumentParser()
-    args = parser.parse_args()
 
+def main():
     # clean up old queues if present
     for port in [5555, 5556, 5557]:
         filename = str(SHMEM_DIR / f'queue-{port}')
@@ -31,6 +27,7 @@ def main():
 
     chip.wait()
 
+
 def start_chip(trace=True):
     cmd = []
     cmd += [EXAMPLE_DIR / 'verilator' / 'obj_dir' / 'Vtestbench']
@@ -44,6 +41,7 @@ def start_chip(trace=True):
 
     return p
 
+
 def start_client():
     cmd = []
     cmd += [EXAMPLE_DIR / 'cpp' / 'client']
@@ -54,6 +52,7 @@ def start_client():
     atexit.register(p.terminate)
 
     return p
+
 
 if __name__ == '__main__':
     main()

--- a/examples/umiram_python/scripts/test.py
+++ b/examples/umiram_python/scripts/test.py
@@ -10,6 +10,7 @@ import numpy as np
 from pathlib import Path
 from switchboard import UmiTxRx, PySbTx, PySbPacket, delete_queue
 
+
 def main():
     # clean up old queues if present
     for q in ["queue-5555", "queue-5556", "queue-5557"]:
@@ -51,6 +52,7 @@ def main():
         print('FAIL')
         sys.exit(1)
 
+
 def start_chip(trace=True):
     this_dir = Path(__file__).resolve().parent
     example_dir = this_dir.parent
@@ -66,6 +68,7 @@ def start_chip(trace=True):
     atexit.register(p.terminate)
 
     return p
+
 
 if __name__ == '__main__':
     main()

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ ext_modules = [
 # provides a convenient way for moving data between C++
 # and Python
 
-setup (
+setup(
     name="switchboard",
     version=__version__,
     author="ZeroASIC",
@@ -33,7 +33,7 @@ setup (
     zip_safe=False,
     python_requires=">=3.7",
     packages=find_packages(),
-    entry_points = {
+    entry_points={
         'console_scripts': [
             'sbtcp=switchboard.sbtcp:main'
         ]

--- a/switchboard/__init__.py
+++ b/switchboard/__init__.py
@@ -3,7 +3,7 @@
 # in the future, there may be some functions implemented directly in Python
 # for now, though, all of the functionality is implemented in C++
 
-from _switchboard import (PySbPacket, delete_queue, umi_opcode_to_str,
+from _switchboard import (PySbPacket, delete_queue, umi_opcode_to_str,  # noqa: F401
     PySbTx, PySbRx, UmiCmd, PySbTxPcie, PySbRxPcie, PyUmiPacket)
 
-from .umi import UmiTxRx
+from .umi import UmiTxRx  # noqa: F401

--- a/switchboard/sbtcp.py
+++ b/switchboard/sbtcp.py
@@ -19,6 +19,7 @@ from switchboard import PySbRx, PySbTx, PySbPacket
 
 SB_PACKET_SIZE_BYTES = 40
 
+
 def conn_closed(conn):
     """
     Check if connection is closed by peeking into the read buffer.
@@ -35,6 +36,7 @@ def conn_closed(conn):
 
     # Connection seems to be alive.
     return False
+
 
 def run_tcp_bridge(sbrx, sbtx, conn, should_yield=True):
     """
@@ -152,6 +154,7 @@ def run_tcp_bridge(sbrx, sbtx, conn, should_yield=True):
         if sb2tcp_votes_to_yield and tcp2sb_votes_to_yield and should_yield:
             time.sleep(0)
 
+
 def run_client(sbrx, sbtx, host, port, quiet=False, should_yield=True):
     """
     Connect to a server, retrying until a connection is made.
@@ -175,6 +178,7 @@ def run_client(sbrx, sbtx, host, port, quiet=False, should_yield=True):
     # communicate with the server
     run_tcp_bridge(sbrx=sbrx, sbtx=sbtx, conn=conn, should_yield=should_yield)
 
+
 def run_server(sbrx, sbtx, host, port, quiet=False, should_yield=True, run_once=False):
     """
     Accepts client connections in a loop until Ctrl-C is pressed.
@@ -182,7 +186,8 @@ def run_server(sbrx, sbtx, host, port, quiet=False, should_yield=True, run_once=
 
     # create the server socket
     server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)  # allow port to be reused immediately
+    server_socket.setsockopt(socket.SOL_SOCKET,
+        socket.SO_REUSEADDR, 1)  # allow port to be reused immediately
     server_socket.bind((host, port))
     server_socket.listen()
 
@@ -199,6 +204,7 @@ def run_server(sbrx, sbtx, host, port, quiet=False, should_yield=True, run_once=
         run_tcp_bridge(sbrx=sbrx, sbtx=sbtx, conn=conn, should_yield=should_yield)
         if (run_once):
             break
+
 
 def main():
     # parse command-line arguments
@@ -231,6 +237,7 @@ def main():
     else:
         raise ValueError(f"Invalid mode: {args.mode}")
 
+
 def sb2bytes(p):
     # construct a bytes object from a Switchboard packet
     arr = np.concatenate((
@@ -239,10 +246,12 @@ def sb2bytes(p):
     ))
     return arr.tobytes()
 
+
 def bytes2sb(b):
     # construct a Switchboard packet from a bytes object
     arr = np.frombuffer(b, dtype=np.uint32)
     return PySbPacket(arr[0], arr[1], arr[2:].view(np.uint8))
+
 
 def get_parser():
     parser = argparse.ArgumentParser()
@@ -268,6 +277,7 @@ def get_parser():
         help="Process only one connection in server mode, then exit.")
 
     return parser
+
 
 if __name__ == "__main__":
     main()

--- a/switchboard/umi.py
+++ b/switchboard/umi.py
@@ -8,10 +8,11 @@ from _switchboard import PyUmi, UmiCmd
 # than have everything in C++, because it was easier to provide
 # flexibility with numpy types
 
+
 class UmiTxRx:
     def __init__(self, tx_uri="", rx_uri=""):
         self.umi = PyUmi(tx_uri, rx_uri)
-    
+
     def init_queues(self, tx_uri="", rx_uri=""):
         self.umi.init(tx_uri, rx_uri)
 
@@ -68,7 +69,7 @@ class UmiTxRx:
         """
         Writes the provided value to the given 64-bit address, and blocks
         until that value is read back from the provided address.
-        
+
         The value can be a plain integer or a numpy integer type.  If it's a
         plain integer, then dtype must be specified, indicating a particular
         numpy integer type (e.g., np.uint16).  This is so that the size of the
@@ -92,8 +93,8 @@ class UmiTxRx:
 
         # set the mask to all ones if it is None
         if mask is None:
-            nbits = (np.dtype(value.dtype).itemsize*8)
-            mask = (1<<nbits) - 1
+            nbits = (np.dtype(value.dtype).itemsize * 8)
+            mask = (1 << nbits) - 1
 
         # convert mask to a numpy datatype if it is not already
         if not isinstance(mask, np.integer):

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import os
-import platform
 import atexit
 import subprocess
 import argparse
@@ -12,6 +11,7 @@ from pathlib import Path
 THIS_DIR = Path(__file__).resolve().parent
 TOP_DIR = THIS_DIR.parent
 SHMEM_DIR = THIS_DIR
+
 
 def main():
     parser = argparse.ArgumentParser()
@@ -38,7 +38,7 @@ def main():
 
     # rx queue numbers
     rx = [None, None]
-    
+
     if args.test in {'hello', 'bandwidth'}:
         rx[1] = next(queue_counter)
     elif args.test in {'latency'}:
@@ -47,7 +47,7 @@ def main():
     else:
         raise Exception(f'Unknown test: {args.test}')
 
-    # split ports based on communication mode     
+    # split ports based on communication mode
     tx = [None, None]
     if args.mode == 'queue':
         tx[0] = rx[1]
@@ -76,7 +76,7 @@ def main():
 
         # start client
         start_bridge(is_server=False, rx_port=tx[1], tx_port=rx[1], verbose=args.verbose)
-    
+
     # run the specific test of interest
     if args.test == 'hello':
         hello = THIS_DIR / 'hello.out'
@@ -91,13 +91,16 @@ def main():
     elif args.test == 'latency':
         latency = THIS_DIR / 'latency.out'
         run_cmd(latency, 'second', rx[0], tx[0], args.iterations, verbose=args.verbose)
-        p = run_cmd(latency, 'first', rx[1], tx[1], args.iterations, auto_exit=False, verbose=args.verbose)
+        p = run_cmd(latency, 'first', rx[1], tx[1], args.iterations,
+            auto_exit=False, verbose=args.verbose)
         p.wait()
     else:
         raise Exception(f'Unknown test: {args.test}')
 
+
 def start_bridge(is_server=False, rx_port=None, tx_port=None,
     tcp_addr='127.0.0.1', tcp_port=7777, verbose=False):
+
     # set defaults
     if rx_port is None:
         rx_port = -1
@@ -112,6 +115,7 @@ def start_bridge(is_server=False, rx_port=None, tx_port=None,
     args += [tcp_port]
 
     return run_cmd(TOP_DIR / 'cpp' / 'tcp-bridge', *args, auto_exit=True, verbose=verbose)
+
 
 def run_cmd(path, *args, auto_exit=True, verbose=False):
     cmd = []
@@ -128,6 +132,7 @@ def run_cmd(path, *args, auto_exit=True, verbose=False):
         atexit.register(p.terminate)
 
     return p
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This PR adds flake8-based Python linting to the switchboard project, using the lint setup from SiliconCompiler as a starting point.  I currently have E128 and E125 as exceptions - both relate to indenting of line continuations, since I usually find flake8 tells me to indent those more than my personal taste.  But I am willing to be convinced otherwise :-)

The Python code changes are just to get the lint check passing and should not have any functional impact.

Intended to be merged via squash-and-merge.