### PR TITLE
Remove upper bound on the SiliconCompiler version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@
 
 numpy
 tqdm
-siliconcompiler >=0.13.1,<0.15
+siliconcompiler >=0.13.1
 
 # Testing dependencies
 #:test

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 from setuptools import setup, find_packages
 from pybind11.setup_helpers import Pybind11Extension, build_ext
 
-__version__ = "0.0.17"
+__version__ = "0.0.19"
 
 ########################################################################
 # parse_reqs() from https://github.com/siliconcompiler/siliconcompiler #


### PR DESCRIPTION
Since there doesn't seem to be a compatibility issue with SiliconCompiler 0.15.0, let's remove the upper bound on the SC version for now, so that we don't have to keep increasing it with new releases.  If there is an incompatibility at some point, we can then decide whether we want to address it directly or put back a constraint on the maximum version.

Note: the version increases from 0.0.17 to 0.0.19 with this release because there is already a tag for `v0.0.18`.