### PR TITLE
Wheels-building CI Action.

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - wr/wheels_build
+      - main
 
 # Ensure C compilation works on MacOS.
 env:


### PR DESCRIPTION
Add an action to build wheels for switchboard.

Tested by `pip install`ing the `.whl` file on Linux / x86_64 / Python 3.8.