### PR TITLE
Delete existing queues if fresh=True SB-380

### DIFF
--- a/examples/python/test.py
+++ b/examples/python/test.py
@@ -6,23 +6,16 @@
 import sys
 import numpy as np
 from argparse import ArgumentParser
-from switchboard import delete_queue, PySbPacket, PySbTx, PySbRx, verilator_run, SbDut
+from switchboard import PySbPacket, PySbTx, PySbRx, verilator_run, SbDut
 
 
-def main(client2rtl='client2rtl.q', rtl2client='rtl2client.q', fast=False):
+def main(fast=False):
     # build the simulator
     verilator_bin = build_testbench(fast=fast)
 
-    # clean up old queues if present
-    for q in [client2rtl, rtl2client]:
-        delete_queue(q)
-
-    # instantiate TX and RX queues.  note that these can be instantiated without
-    # specifying a URI, in which case the URI can be specified later via the
-    # "init" method
-
-    tx = PySbTx(client2rtl)
-    rx = PySbRx(rtl2client)
+    # create queues
+    tx = PySbTx('client2rtl.q', fresh=True)
+    rx = PySbRx('rtl2client.q', fresh=True)
 
     # start chip simulation
     chip = verilator_run(verilator_bin, plusargs=['trace'])

--- a/examples/tcp/test.py
+++ b/examples/tcp/test.py
@@ -5,20 +5,13 @@
 
 import sys
 import numpy as np
-from switchboard import delete_queue, PySbPacket, PySbTx, PySbRx, binary_run
+from switchboard import PySbPacket, PySbTx, PySbRx, binary_run
 
 
 def main(rxq='rx.q', txq='tx.q'):
-    # clean up old queues if present
-    for q in [rxq, txq]:
-        delete_queue(q)
-
-    # instantiate TX and RX queues.  note that these can be instantiated without
-    # specifying a URI, in which case the URI can be specified later via the
-    # "init" method
-
-    tx = PySbTx(rxq)
-    rx = PySbRx(txq)
+    # create queues
+    tx = PySbTx(rxq, fresh=True)
+    rx = PySbRx(txq, fresh=True)
 
     # start TCP bridges
     start_tcp_bridge(mode='server', rx=rxq)

--- a/examples/umi_endpoint/test.py
+++ b/examples/umi_endpoint/test.py
@@ -6,25 +6,18 @@
 import numpy as np
 from pathlib import Path
 from argparse import ArgumentParser
-from switchboard import UmiTxRx, delete_queue, verilator_run, SbDut
+from switchboard import UmiTxRx, verilator_run, SbDut
 
 
-def main(client2rtl="client2rtl.q", rtl2client="rtl2client.q", fast=False):
+def main(fast=False):
     # build the simulator
     verilator_bin = build_testbench(fast=fast)
 
-    # clean up old queues if present
-    for q in [client2rtl, rtl2client]:
-        delete_queue(q)
+    # create queues
+    umi = UmiTxRx("client2rtl.q", "rtl2client.q", fresh=True)
 
     # launch the simulation
     verilator_run(verilator_bin, plusargs=['trace'])
-
-    # instantiate TX and RX queues.  note that these can be instantiated without
-    # specifying a URI, in which case the URI can be specified later via the
-    # "init" method
-
-    umi = UmiTxRx(client2rtl, rtl2client)
 
     print("### MINIMAL EXAMPLE ###")
 

--- a/examples/umi_fifo/test.py
+++ b/examples/umi_fifo/test.py
@@ -5,25 +5,18 @@
 
 from pathlib import Path
 from argparse import ArgumentParser
-from switchboard import UmiTxRx, random_umi_packet, delete_queue, verilator_run, SbDut
+from switchboard import UmiTxRx, random_umi_packet, verilator_run, SbDut
 
 
-def main(client2rtl='client2rtl.q', rtl2client='rtl2client.q', n=3, fast=False):
+def main(n=3, fast=False):
     # build the simulator
     verilator_bin = build_testbench(fast=fast)
 
-    # clean up old queues if present
-    for q in [client2rtl, rtl2client]:
-        delete_queue(q)
+    # create queues
+    umi = UmiTxRx('client2rtl.q', 'rtl2client.q', fresh=True)
 
     # launch the simulation
     verilator_run(verilator_bin, plusargs=['trace'])
-
-    # instantiate TX and RX queues.  note that these can be instantiated without
-    # specifying a URI, in which case the URI can be specified later via the
-    # "init" method
-
-    umi = UmiTxRx(client2rtl, rtl2client)
 
     n_sent = 0
     n_recv = 0

--- a/examples/umi_fifo_flex/test.py
+++ b/examples/umi_fifo_flex/test.py
@@ -5,22 +5,18 @@
 
 from pathlib import Path
 from argparse import ArgumentParser
-from switchboard import SbDut, UmiTxRx, delete_queue, verilator_run, umi_loopback
+from switchboard import SbDut, UmiTxRx, verilator_run, umi_loopback
 
 
-def main(client2rtl="client2rtl.q", rtl2client="rtl2client.q", n=3, fast=False):
+def main(n=3, fast=False):
     # build simulator
     verilator_bin = build_testbench(fast=fast)
 
-    # clean up old queues if present
-    for q in [client2rtl, rtl2client]:
-        delete_queue(q)
+    # create queues
+    umi = UmiTxRx("client2rtl.q", "rtl2client.q", fresh=True)
 
     # launch the simulation
     verilator_run(verilator_bin, plusargs=['trace'])
-
-    # instantiate TX and RX queues
-    umi = UmiTxRx(client2rtl, rtl2client)
 
     # randomly write data
     umi_loopback(umi, n)

--- a/examples/umi_gpio/test.py
+++ b/examples/umi_gpio/test.py
@@ -6,16 +6,15 @@
 import random
 from pathlib import Path
 from argparse import ArgumentParser
-from switchboard import UmiTxRx, delete_queue, verilator_run, SbDut
+from switchboard import UmiTxRx, verilator_run, SbDut
 
 
-def main(client2rtl="client2rtl.q", rtl2client="rtl2client.q", fast=False):
+def main(fast=False):
     # build the simulator
     verilator_bin = build_testbench(fast=fast)
 
-    # clean up old queues if present
-    for q in [client2rtl, rtl2client]:
-        delete_queue(q)
+    # create queues
+    umi = UmiTxRx("client2rtl.q", "rtl2client.q", fresh=True)
 
     # launch the simulation
     verilator_run(verilator_bin, plusargs=['trace'])
@@ -24,7 +23,6 @@ def main(client2rtl="client2rtl.q", rtl2client="rtl2client.q", fast=False):
     # specifying a URI, in which case the URI can be specified later via the
     # "init" method
 
-    umi = UmiTxRx(client2rtl, rtl2client)
     gpio = umi.gpio(owidth=128, iwidth=384, init=0xcafed00d)
 
     print(f'Initial value: 0x{gpio.o[:]:x}')

--- a/examples/umi_mem_cpp/test.py
+++ b/examples/umi_mem_cpp/test.py
@@ -6,8 +6,7 @@ Basic reusable test for a memory chiplet
 
 import numpy as np
 from util import (get_dtype_from_umi_size, dtype_random_data, umi_atomic_op)
-from switchboard import (UmiTxRx, umi_pack, PyUmiPacket, UmiCmd, delete_queue,
-        binary_run)
+from switchboard import (UmiTxRx, umi_pack, PyUmiPacket, UmiCmd, binary_run)
 
 
 def memory_check(umi, device, test_rdma=False):
@@ -147,14 +146,6 @@ def run_atomic(umi, prev, data, cmd, sram_base):
 
 
 if __name__ == '__main__':
-    # clean up old queues if present
-    from_client = 'mem-req-rx.q'
-    to_client = 'mem-rep-tx.q'
-    queues = [from_client, to_client]
-
-    for q in queues:
-        delete_queue(q)
-
-    umi = UmiTxRx(from_client, to_client)
+    umi = UmiTxRx('mem-req-rx.q', 'mem-rep-tx.q', fresh=True)
     binary_run(bin='./umi_mem', args=None)
     memory_check(umi=umi, device=None, test_rdma=False)

--- a/examples/umi_splitter/test.py
+++ b/examples/umi_splitter/test.py
@@ -5,28 +5,25 @@
 
 from pathlib import Path
 from argparse import ArgumentParser
-from switchboard import (UmiTxRx, random_umi_packet, delete_queue,
+from switchboard import (UmiTxRx, random_umi_packet,
     verilator_run, SbDut, UmiCmd, umi_opcode)
 
 
-def main(in_="in.q", out0="out0.q", out1="out1.q", n=3, fast=False):
+def main(n=3, fast=False):
     # build the simulator
     verilator_bin = build_testbench(fast=fast)
 
-    # clean up old queues if present
-    for q in [in_, out0, out1]:
-        delete_queue(q)
+    # create queues
+    umi_in = UmiTxRx("in.q", "", fresh=True)
+    umi_out = [
+        UmiTxRx("", "out0.q", fresh=True),
+        UmiTxRx("", "out1.q", fresh=True)
+    ]
 
     # launch the simulation
     verilator_run(verilator_bin, plusargs=['trace'])
 
-    # instantiate TX and RX queues.  note that these can be instantiated without
-    # specifying a URI, in which case the URI can be specified later via the
-    # "init" method
-
-    umi_in = UmiTxRx(in_, "")
-    umi_out = [UmiTxRx("", out0), UmiTxRx("", out1)]
-
+    # main loop
     tx_req_list = []
     tx_resp_list = []
     rx_list = [[], []]

--- a/python/switchboard_pybind.cc
+++ b/python/switchboard_pybind.cc
@@ -373,13 +373,13 @@ struct PySbRxPcie {
 
 class PySbTx {
   public:
-    PySbTx(std::string uri = "") {
-        init(uri);
+    PySbTx(std::string uri = "", bool fresh = false) {
+        init(uri, fresh);
     }
 
-    void init(std::string uri) {
+    void init(std::string uri, bool fresh = false) {
         if (uri != "") {
-            m_tx.init(uri.c_str());
+            m_tx.init(uri, 0, fresh);
         }
     }
 
@@ -431,13 +431,13 @@ class PySbTx {
 
 class PySbRx {
   public:
-    PySbRx(std::string uri = "") {
-        init(uri);
+    PySbRx(std::string uri = "", bool fresh = false) {
+        init(uri, fresh);
     }
 
-    void init(std::string uri) {
+    void init(std::string uri, bool fresh = false) {
         if (uri != "") {
-            m_rx.init(uri.c_str());
+            m_rx.init(uri, 0, fresh);
         }
     }
 
@@ -505,16 +505,16 @@ static inline void progressbar_done(void) {
 
 class PyUmi {
   public:
-    PyUmi(std::string tx_uri = "", std::string rx_uri = "") {
-        init(tx_uri, rx_uri);
+    PyUmi(std::string tx_uri = "", std::string rx_uri = "", bool fresh = false) {
+        init(tx_uri, rx_uri, fresh);
     }
 
-    void init(std::string tx_uri, std::string rx_uri) {
+    void init(std::string tx_uri, std::string rx_uri, bool fresh = false) {
         if (tx_uri != "") {
-            m_tx.init(tx_uri.c_str());
+            m_tx.init(tx_uri, 0, fresh);
         }
         if (rx_uri != "") {
-            m_rx.init(rx_uri.c_str());
+            m_rx.init(rx_uri, 0, fresh);
         }
     }
 
@@ -818,12 +818,12 @@ PYBIND11_MODULE(_switchboard, m) {
         .def(py::self != py::self);
 
     py::class_<PySbTx>(m, "PySbTx")
-        .def(py::init<std::string>(), py::arg("uri") = "")
+        .def(py::init<std::string, bool>(), py::arg("uri") = "", py::arg("fresh") = false)
         .def("init", &PySbTx::init)
         .def("send", &PySbTx::send, py::arg("py_packet"), py::arg("blocking") = true);
 
     py::class_<PySbRx>(m, "PySbRx")
-        .def(py::init<std::string>(), py::arg("uri") = "")
+        .def(py::init<std::string, bool>(), py::arg("uri") = "", py::arg("fresh") = false)
         .def("init", &PySbRx::init)
         .def("recv", &PySbRx::recv, py::arg("blocking") = true);
 
@@ -840,7 +840,8 @@ PYBIND11_MODULE(_switchboard, m) {
             py::arg("bar_num") = 0, py::arg("bdf") = "");
 
     py::class_<PyUmi>(m, "PyUmi")
-        .def(py::init<std::string, std::string>(), py::arg("tx_uri") = "", py::arg("rx_uri") = "")
+        .def(py::init<std::string, std::string, bool>(), py::arg("tx_uri") = "",
+            py::arg("rx_uri") = "", py::arg("fresh") = false)
         .def("init", &PyUmi::init)
         .def("send", &PyUmi::send, py::arg("py_packet"), py::arg("blocking") = true)
         .def("recv", &PyUmi::recv, py::arg("blocking") = true)

--- a/switchboard/cpp/switchboard.hpp
+++ b/switchboard/cpp/switchboard.hpp
@@ -32,15 +32,21 @@ class SB_base {
         deinit();
     }
 
-    void init(std::string uri) {
-        init(uri.c_str());
+    void init(std::string uri, size_t capacity = 0, bool fresh = false) {
+        init(uri.c_str(), capacity, fresh);
     }
 
-    void init(const char* uri, size_t capacity = 0) {
+    void init(const char* uri, size_t capacity = 0, bool fresh = false) {
         // Default to one page of capacity
         if (capacity == 0) {
             capacity = spsc_capacity(getpagesize());
         }
+
+        // delete old queue if "fresh" is set
+        if (fresh) {
+            spsc_remove_shmfile(uri);
+        }
+
         m_q = spsc_open(uri, capacity);
         m_active = true;
     }

--- a/switchboard/umi.py
+++ b/switchboard/umi.py
@@ -18,7 +18,7 @@ from .gpio import UmiGpio
 class UmiTxRx:
     def __init__(self, tx_uri: str = None, rx_uri: str = None,
         srcaddr: Union[int, Dict[str, int]] = 0, posted: bool = False,
-        max_bytes: int = None):
+        max_bytes: int = None, fresh: bool = False):
         """
         Args:
             tx_uri (str, optional): Name of the switchboard queue that
@@ -49,7 +49,7 @@ class UmiTxRx:
         if rx_uri is None:
             rx_uri = ""
 
-        self.umi = PyUmi(tx_uri, rx_uri)
+        self.umi = PyUmi(tx_uri, rx_uri, fresh)
 
         if srcaddr is not None:
             # convert srcaddr default to a dictionary if necessary
@@ -115,7 +115,7 @@ class UmiTxRx:
             umi=self
         )
 
-    def init_queues(self, tx_uri=None, rx_uri=None):
+    def init_queues(self, tx_uri: str = None, rx_uri: str = None, fresh: bool = False):
         """
         Args:
             tx_uri (str, optional): Name of the switchboard queue that
@@ -132,7 +132,7 @@ class UmiTxRx:
         if rx_uri is None:
             rx_uri = ""
 
-        self.umi.init(tx_uri, rx_uri)
+        self.umi.init(tx_uri, rx_uri, fresh)
 
     def send(self, p, blocking=True) -> bool:
         """


### PR DESCRIPTION
This PR adds a new optional argument, `fresh`, to `UmiTxRx`, `PySbTx`, and `PySbRx` and their `init()` methods.  When `fresh` is `True`, existing queue files are deleted.  For example, `umi = UmiTxRx("", "rx.q", fresh=True)` will delete the file `rx.q` if it exists before creating an RX switchboard connection associated with `rx.q`.

The motivation of this change is to support simpler user code by removing the extra step of deleting existing queues, and to simplify the mental model for working with these objects - creating one creates a queue (or pair of queues).

When using `fresh=True`, the order of operations is:
1. Create `UmiTxRx`, `PySbTx`, and/or `PySbRx` objects.
2. Launch HW models (RTL simulations, C++ models, etc.)
3. Interact with HW models from Python using Switchboard.

This change should be backwards-compatible, because `fresh` defaults to `False`, and the old `delete_queue` method is kept around.  We may want to move towards having `fresh=True` be the default at some point.

Intended to be merged with rebase.