### PR TITLE
Remove the need for Verilator waivers SB-676

### DIFF
--- a/examples/common/verilog/umiram.sv
+++ b/examples/common/verilog/umiram.sv
@@ -39,7 +39,7 @@ module umiram #(
     wire         req_eof;
     wire         req_ex;
     wire [1:0]   req_user;
-    wire [18:0]  req_user_extended;
+    wire [23:0]  req_user_extended;
     wire [1:0]   req_err;
     wire [4:0]   req_hostid;
 
@@ -90,7 +90,7 @@ module umiram #(
     reg         resp_eof;
     reg         resp_ex;
     reg [1:0]   resp_user;
-    reg [18:0]  resp_user_extended;
+    reg [23:0]  resp_user_extended;
     reg [1:0]   resp_err;
     reg [4:0]   resp_hostid;
 
@@ -127,7 +127,7 @@ module umiram #(
     integer i;
 
     function [ATOMIC_WIDTH-1:0] atomic_op(input [ATOMIC_WIDTH-1:0] a,
-        input [ATOMIC_WIDTH-1:0] b, input [3:0] size, input [7:0] atype);
+        input [ATOMIC_WIDTH-1:0] b, input [2:0] size, input [7:0] atype);
 
         integer nbits;
         integer nshift;
@@ -180,7 +180,7 @@ module umiram #(
         if (udev_req_valid && udev_req_ready) begin
             if (req_cmd_posted || req_cmd_write) begin
                 for (i=0; i<nbytes; i=i+1) begin
-                    mem[(i+udev_req_dstaddr)*8 +: 8] <= udev_req_data[i*8 +: 8];
+                    mem[(i+udev_req_dstaddr[31:0])*8 +: 8] <= udev_req_data[i*8 +: 8];
                 end
                 if (req_cmd_write) begin
                     resp_opcode <= UMI_RESP_WRITE;
@@ -188,10 +188,10 @@ module umiram #(
                 end
             end else if (req_cmd_read || req_cmd_atomic) begin
                 for (i=0; i<nbytes; i=i+1) begin
-                    udev_resp_data[i*8 +: 8] <= mem[(i+udev_req_dstaddr)*8 +: 8];
+                    udev_resp_data[i*8 +: 8] <= mem[(i+udev_req_dstaddr[31:0])*8 +: 8];
                     if (req_cmd_atomic) begin
                         // blocking assignment
-                        a_atomic[i*8 +: 8] = mem[(i+udev_req_dstaddr)*8 +: 8];
+                        a_atomic[i*8 +: 8] = mem[(i+udev_req_dstaddr[31:0])*8 +: 8];
                     end
                 end
                 if (req_cmd_atomic) begin
@@ -202,7 +202,7 @@ module umiram #(
                     // blocking assignment
                     y_atomic = atomic_op(a_atomic, b_atomic, req_size, req_atype);
                     for (i=0; i<nbytes; i=i+1) begin
-                        mem[(i+udev_req_dstaddr)*8 +: 8] <= y_atomic[i*8 +: 8];
+                        mem[(i+udev_req_dstaddr[31:0])*8 +: 8] <= y_atomic[i*8 +: 8];
                     end
                 end
                 resp_opcode <= UMI_RESP_READ;

--- a/examples/dependencies.json
+++ b/examples/dependencies.json
@@ -7,7 +7,7 @@
     {
         "name": "lambdalib",
         "url": "git@github.com:siliconcompiler/lambdalib.git",
-        "commit": "88855539259ed15c9649157981727506346f50d2"
+        "commit": "e376b13db46a321e9ffb139895754455c5242b0e"
     },
     {
         "name": "libsystemctlm-soc",

--- a/examples/umi_endpoint/test.py
+++ b/examples/umi_endpoint/test.py
@@ -92,10 +92,6 @@ def build_testbench(fast=False):
         dut.add('option', option, EX_DIR / 'deps' / 'umi' / 'umi' / 'rtl')
         dut.add('option', option, EX_DIR / 'deps' / 'lambdalib' / 'stdlib' / 'rtl')
 
-    # Verilator configuration
-    vlt_config = EX_DIR / 'common' / 'verilator' / 'config.vlt'
-    dut.set('tool', 'verilator', 'task', 'compile', 'file', 'config', vlt_config)
-
     # Settings
     dut.set('option', 'trace', True)  # enable VCD (TODO: FST option)
 

--- a/examples/umi_fifo/test.py
+++ b/examples/umi_fifo/test.py
@@ -63,10 +63,6 @@ def build_testbench(fast=False):
         dut.add('option', option, EX_DIR / 'deps' / 'lambdalib' / 'ramlib' / 'rtl')
         dut.add('option', option, EX_DIR / 'deps' / 'lambdalib' / 'stdlib' / 'rtl')
 
-    # Verilator configuration
-    vlt_config = EX_DIR / 'common' / 'verilator' / 'config.vlt'
-    dut.set('tool', 'verilator', 'task', 'compile', 'file', 'config', vlt_config)
-
     # Settings
     dut.set('option', 'trace', True)  # enable VCD (TODO: FST option)
 

--- a/examples/umi_fifo_flex/test.py
+++ b/examples/umi_fifo_flex/test.py
@@ -40,10 +40,6 @@ def build_testbench(fast=False):
         dut.add('option', option, EX_DIR / 'deps' / 'lambdalib' / 'ramlib' / 'rtl')
         dut.add('option', option, EX_DIR / 'deps' / 'lambdalib' / 'stdlib' / 'rtl')
 
-    # Verilator configuration
-    vlt_config = EX_DIR / 'common' / 'verilator' / 'config.vlt'
-    dut.set('tool', 'verilator', 'task', 'compile', 'file', 'config', vlt_config)
-
     # Settings
     dut.set('option', 'trace', True)  # enable VCD (TODO: FST option)
 

--- a/examples/umi_gpio/test.py
+++ b/examples/umi_gpio/test.py
@@ -81,10 +81,6 @@ def build_testbench(fast=False):
     for option in ['ydir', 'idir']:
         dut.add('option', option, EX_DIR / 'deps' / 'umi' / 'umi' / 'rtl')
 
-    # Verilator configuration
-    vlt_config = EX_DIR / 'common' / 'verilator' / 'config.vlt'
-    dut.set('tool', 'verilator', 'task', 'compile', 'file', 'config', vlt_config)
-
     # Settings
     dut.set('option', 'trace', True)  # enable VCD (TODO: FST option)
 

--- a/examples/umi_splitter/test.py
+++ b/examples/umi_splitter/test.py
@@ -75,10 +75,6 @@ def build_testbench(fast=False):
         dut.add('option', option, EX_DIR / 'deps' / 'lambdalib' / 'ramlib' / 'rtl')
         dut.add('option', option, EX_DIR / 'deps' / 'lambdalib' / 'stdlib' / 'rtl')
 
-    # Verilator configuration
-    vlt_config = EX_DIR / 'common' / 'verilator' / 'config.vlt'
-    dut.set('tool', 'verilator', 'task', 'compile', 'file', 'config', vlt_config)
-
     # Settings
     dut.set('option', 'trace', True)  # enable VCD (TODO: FST option)
 

--- a/examples/umiram/test.py
+++ b/examples/umiram/test.py
@@ -101,10 +101,6 @@ def build_testbench(fast=False):
     for option in ['ydir', 'idir']:
         dut.add('option', option, EX_DIR / 'deps' / 'umi' / 'umi' / 'rtl')
 
-    # Verilator configuration
-    vlt_config = EX_DIR / 'common' / 'verilator' / 'config.vlt'
-    dut.set('tool', 'verilator', 'task', 'compile', 'file', 'config', vlt_config)
-
     # Settings
     dut.set('option', 'trace', True)  # enable VCD (TODO: FST option)
 


### PR DESCRIPTION
After fixing lint warnings in `umiram` (from this repo) and `la_asyncfifo` (from lambdalib), the Verilator waiver file wasn't necessary anymore and could be removed.

Intended to be merged via rebase.