### PR TITLE
Update for Compatibility with Verilator v5.018

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -14,7 +14,7 @@ jobs:
     name: Verilator
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/zeroasiccorp/sbtest:0.0.9
+      image: ghcr.io/zeroasiccorp/sbtest:0.0.10
       credentials:
          username: ${{ secrets.ZA_ACTOR }}
          password: ${{ secrets.ZA_TOKEN }}
@@ -53,7 +53,7 @@ jobs:
     name: FPGA queue simulation
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/zeroasiccorp/sbtest:0.0.9
+      image: ghcr.io/zeroasiccorp/sbtest:0.0.10
       credentials:
          username: ${{ secrets.ZA_ACTOR }}
          password: ${{ secrets.ZA_TOKEN }}


### PR DESCRIPTION
Looks like https://github.com/zeroasiccorp/switchboard/pull/144 resolved all Verilator related errors and warnings. Regression tests now work with verilator 'v5.018'.

This PR only bumps the regression container to `sbtest:0.0.10` which includes Verilator `v5.018`.