### PR TITLE
TODO item cleanup

### DIFF
--- a/examples/python/test.py
+++ b/examples/python/test.py
@@ -70,7 +70,7 @@ def build_testbench(fast=False):
     dut.input('testbench.sv')
 
     # Settings
-    dut.set('option', 'trace', True)  # enable VCD (TODO: FST option)
+    dut.set('option', 'trace', True)  # enable VCD
 
     result = None
 

--- a/examples/router/test.py
+++ b/examples/router/test.py
@@ -45,7 +45,7 @@ def build_testbench(fast=False):
     dut.input('testbench.sv')
 
     # Settings
-    dut.set('option', 'trace', True)  # enable VCD (TODO: FST option)
+    dut.set('option', 'trace', True)  # enable VCD
 
     result = None
 

--- a/examples/stream/test.py
+++ b/examples/stream/test.py
@@ -37,7 +37,7 @@ def build_testbench():
     dut.input('testbench.sv')
 
     # Settings
-    dut.set('option', 'trace', True)  # enable VCD (TODO: FST option)
+    dut.set('option', 'trace', True)  # enable VCD
 
     # Build simulator
     dut.run()

--- a/examples/umi_endpoint/test.py
+++ b/examples/umi_endpoint/test.py
@@ -85,7 +85,7 @@ def build_testbench(fast=False):
         dut.add('option', option, EX_DIR / 'deps' / 'lambdalib' / 'stdlib' / 'rtl')
 
     # Settings
-    dut.set('option', 'trace', True)  # enable VCD (TODO: FST option)
+    dut.set('option', 'trace', True)  # enable VCD
 
     result = None
 

--- a/examples/umi_fifo/test.py
+++ b/examples/umi_fifo/test.py
@@ -56,7 +56,7 @@ def build_testbench(fast=False):
         dut.add('option', option, EX_DIR / 'deps' / 'lambdalib' / 'stdlib' / 'rtl')
 
     # Settings
-    dut.set('option', 'trace', True)  # enable VCD (TODO: FST option)
+    dut.set('option', 'trace', True)  # enable VCD
 
     result = None
 

--- a/examples/umi_fifo/testbench.sv
+++ b/examples/umi_fifo/testbench.sv
@@ -42,7 +42,7 @@ module testbench (
         .valid(udev_resp_valid)
     );
 
-    wire nreset;
+    reg nreset = 1'b0;
 
     umi_fifo #(
         .DW(DW),
@@ -75,14 +75,9 @@ module testbench (
         .vss(1'b0)
     );
 
-    reg [7:0] nreset_vec = 8'h00;
     always @(posedge clk) begin
-        nreset_vec <= {nreset_vec[6:0], 1'b1};
+        nreset <= 1'b1;
     end
-
-    // TODO: investigate reset sequencing issue
-
-    assign nreset = nreset_vec[7];
 
     // Initialize UMI
 

--- a/examples/umi_fifo_flex/test.py
+++ b/examples/umi_fifo_flex/test.py
@@ -35,7 +35,7 @@ def build_testbench(fast=False):
         dut.add('option', option, EX_DIR / 'deps' / 'lambdalib' / 'stdlib' / 'rtl')
 
     # Settings
-    dut.set('option', 'trace', True)  # enable VCD (TODO: FST option)
+    dut.set('option', 'trace', True)  # enable VCD
 
     result = None
 

--- a/examples/umi_fifo_flex/testbench.sv
+++ b/examples/umi_fifo_flex/testbench.sv
@@ -22,7 +22,7 @@ module testbench (
     wire [AW-1:0] udev_resp_srcaddr;
     wire [DW-1:0] udev_resp_data;
 
-    wire nreset;
+    reg nreset = 1'b0;
 
     queue_to_umi_sim #(
         .VALID_MODE_DEFAULT(2)
@@ -79,12 +79,9 @@ module testbench (
         .vss(1'b0)
     );
 
-    reg [7:0] nreset_vec = 8'h00;
     always @(posedge clk) begin
-        nreset_vec <= {nreset_vec[6:0], 1'b1};
+        nreset <= 1'b1;
     end
-
-    assign nreset = nreset_vec[7];
 
     // Initialize UMI
 

--- a/examples/umi_gpio/test.py
+++ b/examples/umi_gpio/test.py
@@ -79,7 +79,7 @@ def build_testbench(fast=False):
         dut.add('option', option, EX_DIR / 'deps' / 'umi' / 'umi' / 'rtl')
 
     # Settings
-    dut.set('option', 'trace', True)  # enable VCD (TODO: FST option)
+    dut.set('option', 'trace', True)  # enable VCD
 
     result = None
 

--- a/examples/umi_splitter/test.py
+++ b/examples/umi_splitter/test.py
@@ -72,7 +72,7 @@ def build_testbench(fast=False):
         dut.add('option', option, EX_DIR / 'deps' / 'lambdalib' / 'stdlib' / 'rtl')
 
     # Settings
-    dut.set('option', 'trace', True)  # enable VCD (TODO: FST option)
+    dut.set('option', 'trace', True)  # enable VCD
 
     result = None
 

--- a/python/switchboard_pybind.cc
+++ b/python/switchboard_pybind.cc
@@ -768,7 +768,6 @@ class PyUmi {
         umisb_recv<PyUmiPacket>(resp, m_rx, true, &check_signals);
 
         // check that the response makes sense
-        // TODO: replace with the atomic response opcode
         umisb_check_resp(resp, UMI_RESP_READ, size, 1, srcaddr);
 
         // return the result of the operation

--- a/switchboard/verilog/sim/perf_meas_sim.sv
+++ b/switchboard/verilog/sim/perf_meas_sim.sv
@@ -1,7 +1,6 @@
 `default_nettype none
 
 module perf_meas_sim #(
-    // TODO: look into changing the parameter style
     // verilog_lint: waive-start parameter-name-style
     parameter integer default_cycles_per_meas=0,
     parameter real max_report_time=3.0,

--- a/switchboard/vpi/switchboard_vpi.cc
+++ b/switchboard/vpi/switchboard_vpi.cc
@@ -219,7 +219,6 @@ PLI_INT32 pi_sb_send(PLI_BYTE8* userdata) {
     }
 
     // get outgoing packet
-    // TODO: possible to use vpi_get_value_array?
     sb_packet p;
     {
         t_vpi_value argval;

--- a/tests/latency.cc
+++ b/tests/latency.cc
@@ -61,7 +61,6 @@ int main(int argc, char* argv[]) {
                 ;
 
             for (int i = 0; i < 8; i++) {
-                // TODO: clean this up...
                 (*((uint32_t*)(&p.data[4 * i])))++;
             }
 
@@ -71,7 +70,6 @@ int main(int argc, char* argv[]) {
         // print output to make sure it is not optimized away
         printf("Output: {");
         for (int i = 0; i < 8; i++) {
-            // TODO: clean this up...
             printf("%0d", *((uint32_t*)(&p.data[4 * i])));
             if (i != 7) {
                 printf(", ");
@@ -94,7 +92,6 @@ int main(int argc, char* argv[]) {
                 ;
 
             for (int i = 0; i < 8; i++) {
-                // TODO: clean this up...
                 (*((uint32_t*)(&p.data[4 * i])))++;
             }
 


### PR DESCRIPTION
This PR removes TODO items that were resolved or are no longer issues at this point.  In one case (testbench Verilog for UMI FIFO testing), I was able to simplify the RTL to remove a TODO.

I created GitHub Issues for the other TODO items that are left open, yielding about a dozen new issues.  Some of these are pretty small and could be a good first issue for new developers!