### PR TITLE
sbdut: simulate: Build simulator if needed

### DIFF
--- a/switchboard/sbdut.py
+++ b/switchboard/sbdut.py
@@ -84,7 +84,8 @@ class SbDut(siliconcompiler.Chip):
         return self.sim
 
     def simulate(self, plusargs=None, extra_args=None):
-        assert self.sim is not None
+        if self.sim is None:
+            self.build()
 
         p = None
         if self.tool == 'verilator':


### PR DESCRIPTION
This patch builds the simulator (if it hasn't already been built) in the simulate() method.

I forgot to include this patch in the previous PR, it was sitting uncomitted in my tree...