### PR TITLE
Try speeding up pip install in the regression tests.

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -13,10 +13,6 @@ jobs:
   verilator:
     name: Verilator
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python: ["3.8", "3.9", "3.10", "3.11"]
     container:
       image: ghcr.io/zeroasiccorp/sbtest:0.0.10
       credentials:
@@ -28,15 +24,6 @@ jobs:
         with:
           token: ${{ secrets.ZA_TOKEN }}
           submodules: true
-
-      - name: Update apt cache
-        run: apt-get update && apt-get install lsb-release
-
-      - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python }}
-          cache: pip
 
       - name: Install Switchboard Python package
         run: |
@@ -65,10 +52,6 @@ jobs:
   fpga_sim:
     name: FPGA queue simulation
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python: ["3.8", "3.9", "3.10", "3.11"]
     container:
       image: ghcr.io/zeroasiccorp/sbtest:0.0.10
       credentials:
@@ -80,12 +63,6 @@ jobs:
         with:
           token: ${{ secrets.ZA_TOKEN }}
           submodules: true
-
-      - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python }}
-          cache: pip
 
       - name: Install Switchboard Python package
         run: |


### PR DESCRIPTION
I tried several suggestions for parallelizing or speeding up `pip install`s, but only one had any appreciable impact on build time (~5% reduction): setting `MAKEFLAGS=-j$(nproc)` so that `pip` will run `make` commands with multiple threads.

This doesn't seem to help as much on the GH Actions runners (which only have two cores) as it does on a laptop, though. It would be nice if we could have the environment variable set by `setup.py` / `pyproject.toml`, but there doesn't seem to be a good way to do that. `os.system(export ...)` might work in `setup.py`, but that's essentially calling `exec` which is bad practice.

The only other thing that I think could help would be to cache the pypi packages in the sbtest container image, but then we'd need to update the container image with each new dependency version, and it wouldn't help with local installs.