### PR TITLE
Make all examples work with Icarus Verilog

### DIFF
--- a/examples/common/verilog/umiram.sv
+++ b/examples/common/verilog/umiram.sv
@@ -25,7 +25,7 @@ module umiram #(
     output     [CW-1:0] udev_resp_cmd,
     output reg [AW-1:0] udev_resp_dstaddr='d0,
     output     [AW-1:0] udev_resp_srcaddr,
-    output     [DW-1:0] udev_resp_data
+    output reg [DW-1:0] udev_resp_data='d0
 );
 
     `include "umi_messages.vh"

--- a/examples/minimal/Makefile
+++ b/examples/minimal/Makefile
@@ -6,11 +6,11 @@ SBDIR := $(shell switchboard --path)
 
 .PHONY: verilator
 verilator: client
-	./test.py verilator
+	./test.py --tool verilator
 
 .PHONY: icarus
 icarus: client
-	./test.py icarus
+	./test.py --tool icarus
 
 client: client.cc $(SBDIR)/cpp/switchboard.hpp
 	g++ -std=c++11 -I$(SBDIR)/cpp $< -o $@

--- a/examples/minimal/test.py
+++ b/examples/minimal/test.py
@@ -12,9 +12,9 @@ from switchboard import SbDut, delete_queues, binary_run
 THIS_DIR = Path(__file__).resolve().parent
 
 
-def main(mode="verilator"):
+def main(tool="verilator"):
     # build the simulator
-    dut = SbDut(tool=mode, default_main=True)
+    dut = SbDut(tool=tool, default_main=True)
     dut.input('testbench.sv')
     dut.build(fast=True)
 
@@ -34,7 +34,8 @@ def main(mode="verilator"):
 
 if __name__ == '__main__':
     parser = ArgumentParser()
-    parser.add_argument('mode', default='verilator')
+    parser.add_argument('--tool', default='verilator', choices=['icarus', 'verilator'],
+        help='Name of the simulator to use.')
     args = parser.parse_args()
 
-    main(mode=args.mode)
+    main(tool=args.tool)

--- a/examples/minimal/testbench.sv
+++ b/examples/minimal/testbench.sv
@@ -2,13 +2,13 @@
 // This code is licensed under Apache License 2.0 (see LICENSE for details)
 
 module testbench (
-    `ifndef __ICARUS__
+    `ifdef VERILATOR
         input clk
     `endif
 );
     // clock
 
-    `ifdef __ICARUS__
+    `ifndef VERILATOR
 
         reg clk;
         always begin

--- a/examples/python/Makefile
+++ b/examples/python/Makefile
@@ -1,9 +1,13 @@
 # Copyright (c) 2023 Zero ASIC Corporation
 # This code is licensed under Apache License 2.0 (see LICENSE for details)
 
-.PHONY: python
-python:
-	./test.py
+.PHONY: verilator
+verilator:
+	./test.py --tool verilator
+
+.PHONY: icarus
+icarus:
+	./test.py --tool icarus
 
 .PHONY: clean
 clean:

--- a/examples/python/test.py
+++ b/examples/python/test.py
@@ -11,9 +11,9 @@ from argparse import ArgumentParser
 from switchboard import PySbPacket, PySbTx, PySbRx, SbDut
 
 
-def main(fast=False):
+def main(fast=False, tool='verilator'):
     # build the simulator
-    dut = SbDut(default_main=True)
+    dut = SbDut(tool=tool, default_main=True)
     dut.input('testbench.sv')
     dut.build(fast=fast)
 
@@ -71,6 +71,8 @@ if __name__ == '__main__':
     parser = ArgumentParser()
     parser.add_argument('--fast', action='store_true', help='Do not build'
         ' the simulator binary if it has already been built.')
+    parser.add_argument('--tool', default='verilator', choices=['icarus', 'verilator'],
+        help='Name of the simulator to use.')
     args = parser.parse_args()
 
-    main(fast=args.fast)
+    main(fast=args.fast, tool=args.tool)

--- a/examples/python/testbench.sv
+++ b/examples/python/testbench.sv
@@ -2,8 +2,24 @@
 // This code is licensed under Apache License 2.0 (see LICENSE for details)
 
 module testbench (
-    input clk
+    `ifdef VERILATOR
+        input clk
+    `endif
 );
+    // clock
+
+    `ifndef VERILATOR
+
+        reg clk;
+        always begin
+            clk = 1'b0;
+            #5;
+            clk = 1'b1;
+            #5;
+        end
+
+    `endif
+
     // SB RX port
 
     wire [255:0] sb_rx_data;

--- a/examples/router/Makefile
+++ b/examples/router/Makefile
@@ -3,9 +3,13 @@
 
 SBDIR := $(shell switchboard --path)
 
-.PHONY: cpp
-cpp: client $(SBDIR)/cpp/router
-	./test.py
+.PHONY: verilator
+verilator: client $(SBDIR)/cpp/router
+	./test.py --tool verilator
+
+.PHONY: icarus
+icarus: client $(SBDIR)/cpp/router
+	./test.py --tool icarus
 
 $(SBDIR)/cpp/router:
 	make -C $(SBDIR)/cpp router

--- a/examples/router/test.py
+++ b/examples/router/test.py
@@ -12,9 +12,9 @@ from switchboard import switchboard, delete_queue, binary_run, SbDut
 THIS_DIR = Path(__file__).resolve().parent
 
 
-def main(aq="5555", bq="5556", cq="5557", dq="5558", fast=False):
+def main(aq="5555", bq="5556", cq="5557", dq="5558", tool="verilator", fast=False):
     # build the simulator
-    dut = SbDut(default_main=True)
+    dut = SbDut(tool=tool, default_main=True)
     dut.input('testbench.sv')
     dut.build(fast=fast)
 
@@ -46,6 +46,8 @@ if __name__ == '__main__':
     parser = ArgumentParser()
     parser.add_argument('--fast', action='store_true', help='Do not build'
         ' the simulator binary if it has already been built.')
+    parser.add_argument('--tool', default='verilator', choices=['icarus', 'verilator'],
+        help='Name of the simulator to use.')
     args = parser.parse_args()
 
     main(fast=args.fast)

--- a/examples/router/testbench.sv
+++ b/examples/router/testbench.sv
@@ -2,8 +2,24 @@
 // This code is licensed under Apache License 2.0 (see LICENSE for details)
 
 module testbench (
-    input clk
+    `ifdef VERILATOR
+        input clk
+    `endif
 );
+    // clock
+
+    `ifndef VERILATOR
+
+        reg clk;
+        always begin
+            clk = 1'b0;
+            #5;
+            clk = 1'b1;
+            #5;
+        end
+
+    `endif
+
     // SB RX port
 
     wire [255:0] sb_rx_data;

--- a/examples/stream/Makefile
+++ b/examples/stream/Makefile
@@ -3,9 +3,13 @@
 
 SBDIR := $(shell switchboard --path)
 
-.PHONY: cpp
-cpp: client
-	./test.py
+.PHONY: verilator
+verilator: client
+	./test.py --tool verilator
+
+.PHONY: icarus
+icarus: client
+	./test.py --tool icarus
 
 client: client.cc $(SBDIR)/cpp/switchboard.hpp
 	g++ -std=c++11 -I$(SBDIR)/cpp $< -o $@

--- a/examples/stream/test.py
+++ b/examples/stream/test.py
@@ -8,16 +8,17 @@
 import time
 
 from pathlib import Path
+from argparse import ArgumentParser
 from switchboard import delete_queues, binary_run, SbDut
 
 THIS_DIR = Path(__file__).resolve().parent
 
 
-def main():
+def main(tool="verilator", fast=False):
     # build the simulator
-    dut = SbDut(default_main=True)
+    dut = SbDut(tool=tool, default_main=True)
     dut.input('testbench.sv')
-    dut.build()
+    dut.build(fast=fast)
 
     # clean up old queues if present
     delete_queues(['client2rtl.q', 'rtl2client.q'])
@@ -34,4 +35,11 @@ def main():
 
 
 if __name__ == '__main__':
+    parser = ArgumentParser()
+    parser.add_argument('--fast', action='store_true', help='Do not build'
+        ' the simulator binary if it has already been built.')
+    parser.add_argument('--tool', default='verilator', choices=['icarus', 'verilator'],
+        help='Name of the simulator to use.')
+    args = parser.parse_args()
+
     main()

--- a/examples/stream/testbench.sv
+++ b/examples/stream/testbench.sv
@@ -2,8 +2,24 @@
 // This code is licensed under Apache License 2.0 (see LICENSE for details)
 
 module testbench (
-    input clk
+    `ifdef VERILATOR
+        input clk
+    `endif
 );
+    // clock
+
+    `ifndef VERILATOR
+
+        reg clk;
+        always begin
+            clk = 1'b0;
+            #5;
+            clk = 1'b1;
+            #5;
+        end
+
+    `endif
+
     // SB RX port
 
     wire [255:0] sb_rx_data;

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -18,7 +18,7 @@ THIS_DIR = Path(__file__).resolve().parent
     ['minimal', 'PASS!', 'verilator'],
     ['minimal', 'PASS!', 'icarus'],
     ['umi_mem_cpp', None, None],
-    ['umiram', None, 'python'],
+    ['umiram', None, 'verilator'],
     ['umiram', None, 'cpp'],
     ['python', 'PASS!', None],
     ['router', 'PASS!', None],

--- a/examples/umi_endpoint/Makefile
+++ b/examples/umi_endpoint/Makefile
@@ -1,9 +1,13 @@
 # Copyright (c) 2023 Zero ASIC Corporation
 # This code is licensed under Apache License 2.0 (see LICENSE for details)
 
-.PHONY: python
-python:
-	./test.py
+.PHONY: verilator
+verilator:
+	./test.py --tool verilator
+
+.PHONY: icarus
+icarus:
+	./test.py --tool icarus
 
 .PHONY: clean
 clean:

--- a/examples/umi_endpoint/test.py
+++ b/examples/umi_endpoint/test.py
@@ -11,9 +11,9 @@ from argparse import ArgumentParser
 from switchboard import UmiTxRx, SbDut
 
 
-def main(fast=False):
+def main(fast=False, tool='verilator'):
     # build the simulator
-    dut = build_testbench(fast=fast)
+    dut = build_testbench(fast=fast, tool=tool)
 
     # create queues
     umi = UmiTxRx("to_rtl.q", "from_rtl.q", fresh=True)
@@ -75,8 +75,8 @@ def main(fast=False):
     assert val64 == 0xBAADD00DCAFEFACE
 
 
-def build_testbench(fast=False):
-    dut = SbDut(default_main=True)
+def build_testbench(fast=False, tool='verilator'):
+    dut = SbDut(tool=tool, default_main=True)
 
     EX_DIR = Path('..').resolve()
 
@@ -94,6 +94,8 @@ if __name__ == '__main__':
     parser = ArgumentParser()
     parser.add_argument('--fast', action='store_true', help='Do not build'
         ' the simulator binary if it has already been built.')
+    parser.add_argument('--tool', default='verilator', choices=['icarus', 'verilator'],
+        help='Name of the simulator to use.')
     args = parser.parse_args()
 
-    main(fast=args.fast)
+    main(fast=args.fast, tool=args.tool)

--- a/examples/umi_endpoint/testbench.sv
+++ b/examples/umi_endpoint/testbench.sv
@@ -4,8 +4,21 @@
 `default_nettype none
 
 module testbench (
-    input clk
+    `ifdef VERILATOR
+        input clk
+    `endif
 );
+    `ifndef VERILATOR
+
+        reg clk;
+        always begin
+            clk = 1'b0;
+            #5;
+            clk = 1'b1;
+            #5;
+        end
+
+    `endif
 
     parameter integer DW=256;
     parameter integer AW=64;

--- a/examples/umi_fifo/Makefile
+++ b/examples/umi_fifo/Makefile
@@ -1,9 +1,13 @@
 # Copyright (c) 2023 Zero ASIC Corporation
 # This code is licensed under Apache License 2.0 (see LICENSE for details)
 
-.PHONY: python
-python:
-	./test.py
+.PHONY: verilator
+verilator:
+	./test.py --tool verilator
+
+.PHONY: icarus
+icarus:
+	./test.py --tool icarus
 
 .PHONY: clean
 clean:

--- a/examples/umi_fifo/test.py
+++ b/examples/umi_fifo/test.py
@@ -10,9 +10,9 @@ from argparse import ArgumentParser
 from switchboard import UmiTxRx, random_umi_packet, SbDut
 
 
-def main(n=3, fast=False):
+def main(n=3, fast=False, tool='verilator'):
     # build the simulator
-    dut = build_testbench(fast=fast)
+    dut = build_testbench(fast=fast, tool=tool)
 
     # create queues
     umi = UmiTxRx('to_rtl.q', 'from_rtl.q', fresh=True)
@@ -45,8 +45,8 @@ def main(n=3, fast=False):
                     n_recv += 1
 
 
-def build_testbench(fast=False):
-    dut = SbDut(default_main=True)
+def build_testbench(fast=False, tool='verilator'):
+    dut = SbDut(tool=tool, default_main=True)
 
     EX_DIR = Path('..').resolve()
 
@@ -67,6 +67,8 @@ if __name__ == '__main__':
         ' transactions to send into the FIFO during the test.')
     parser.add_argument('--fast', action='store_true', help='Do not build'
         ' the simulator binary if it has already been built.')
+    parser.add_argument('--tool', default='verilator', choices=['icarus', 'verilator'],
+        help='Name of the simulator to use.')
     args = parser.parse_args()
 
-    main(n=args.n, fast=args.fast)
+    main(n=args.n, fast=args.fast, tool=args.tool)

--- a/examples/umi_fifo/testbench.sv
+++ b/examples/umi_fifo/testbench.sv
@@ -4,8 +4,21 @@
 `default_nettype none
 
 module testbench (
-    input clk
+    `ifdef VERILATOR
+        input clk
+    `endif
 );
+    `ifndef VERILATOR
+
+        reg clk;
+        always begin
+            clk = 1'b0;
+            #5;
+            clk = 1'b1;
+            #5;
+        end
+
+    `endif
 
     parameter integer DW=256;
     parameter integer AW=64;

--- a/examples/umi_fifo_flex/Makefile
+++ b/examples/umi_fifo_flex/Makefile
@@ -1,9 +1,13 @@
 # Copyright (c) 2023 Zero ASIC Corporation
 # This code is licensed under Apache License 2.0 (see LICENSE for details)
 
-.PHONY: python
-python:
-	./test.py
+.PHONY: verilator
+verilator:
+	./test.py --tool verilator
+
+.PHONY: icarus
+icarus:
+	./test.py --tool icarus
 
 .PHONY: clean
 clean:

--- a/examples/umi_fifo_flex/test.py
+++ b/examples/umi_fifo_flex/test.py
@@ -10,9 +10,9 @@ from argparse import ArgumentParser
 from switchboard import SbDut, UmiTxRx, umi_loopback
 
 
-def main(n=3, fast=False):
+def main(n=3, fast=False, tool='verilator'):
     # build simulator
-    dut = build_testbench(fast=fast)
+    dut = build_testbench(fast=fast, tool=tool)
 
     # create queues
     umi = UmiTxRx("to_rtl.q", "from_rtl.q", fresh=True)
@@ -24,8 +24,8 @@ def main(n=3, fast=False):
     umi_loopback(umi, n)
 
 
-def build_testbench(fast=False):
-    dut = SbDut(default_main=True)
+def build_testbench(fast=False, tool='verilator'):
+    dut = SbDut(tool=tool, default_main=True)
 
     EX_DIR = Path('..').resolve()
 
@@ -46,6 +46,8 @@ if __name__ == '__main__':
         ' transactions to send into the FIFO during the test.')
     parser.add_argument('--fast', action='store_true', help='Do not build'
         ' the simulator binary if it has already been built.')
+    parser.add_argument('--tool', default='verilator', choices=['icarus', 'verilator'],
+        help='Name of the simulator to use.')
     args = parser.parse_args()
 
-    main(n=args.n, fast=args.fast)
+    main(n=args.n, fast=args.fast, tool=args.tool)

--- a/examples/umi_fifo_flex/testbench.sv
+++ b/examples/umi_fifo_flex/testbench.sv
@@ -4,8 +4,21 @@
 `default_nettype none
 
 module testbench (
-    input clk
+    `ifdef VERILATOR
+        input clk
+    `endif
 );
+    `ifndef VERILATOR
+
+        reg clk;
+        always begin
+            clk = 1'b0;
+            #5;
+            clk = 1'b1;
+            #5;
+        end
+
+    `endif
 
     parameter integer DW=256;
     parameter integer AW=64;

--- a/examples/umi_gpio/Makefile
+++ b/examples/umi_gpio/Makefile
@@ -1,9 +1,13 @@
 # Copyright (c) 2023 Zero ASIC Corporation
 # This code is licensed under Apache License 2.0 (see LICENSE for details)
 
-.PHONY: python
-python:
-	./test.py
+.PHONY: verilator
+verilator:
+	./test.py --tool verilator
+
+.PHONY: icarus
+icarus:
+	./test.py --tool icarus
 
 .PHONY: clean
 clean:

--- a/examples/umi_gpio/test.py
+++ b/examples/umi_gpio/test.py
@@ -11,9 +11,9 @@ from argparse import ArgumentParser
 from switchboard import UmiTxRx, SbDut
 
 
-def main(fast=False):
+def main(fast=False, tool='verilator'):
     # build the simulator
-    dut = build_testbench(fast=fast)
+    dut = build_testbench(fast=fast, tool=tool)
 
     # create queues
     umi = UmiTxRx("to_rtl.q", "from_rtl.q", fresh=True)
@@ -70,8 +70,8 @@ def main(fast=False):
     print('PASS!')
 
 
-def build_testbench(fast=False):
-    dut = SbDut(default_main=True)
+def build_testbench(fast=False, tool='verilator'):
+    dut = SbDut(tool=tool, default_main=True)
 
     EX_DIR = Path('..').resolve()
 
@@ -88,6 +88,8 @@ if __name__ == '__main__':
     parser = ArgumentParser()
     parser.add_argument('--fast', action='store_true', help='Do not build'
         ' the simulator binary if it has already been built.')
+    parser.add_argument('--tool', default='verilator', choices=['icarus', 'verilator'],
+        help='Name of the simulator to use.')
     args = parser.parse_args()
 
-    main(fast=args.fast)
+    main(fast=args.fast, tool=args.tool)

--- a/examples/umi_gpio/testbench.sv
+++ b/examples/umi_gpio/testbench.sv
@@ -4,8 +4,21 @@
 `default_nettype none
 
 module testbench (
-    input clk
+    `ifdef VERILATOR
+        input clk
+    `endif
 );
+    `ifndef VERILATOR
+
+        reg clk;
+        always begin
+            clk = 1'b0;
+            #5;
+            clk = 1'b1;
+            #5;
+        end
+
+    `endif
 
     parameter integer DW=256;
     parameter integer AW=64;

--- a/examples/umi_splitter/Makefile
+++ b/examples/umi_splitter/Makefile
@@ -1,9 +1,13 @@
 # Copyright (c) 2023 Zero ASIC Corporation
 # This code is licensed under Apache License 2.0 (see LICENSE for details)
 
-.PHONY: python
-python:
-	./test.py
+.PHONY: verilator
+verilator:
+	./test.py --tool verilator
+
+.PHONY: icarus
+icarus:
+	./test.py --tool icarus
 
 .PHONY: clean
 clean:

--- a/examples/umi_splitter/test.py
+++ b/examples/umi_splitter/test.py
@@ -10,9 +10,9 @@ from argparse import ArgumentParser
 from switchboard import UmiTxRx, random_umi_packet, SbDut, UmiCmd, umi_opcode
 
 
-def main(n=3, fast=False):
+def main(n=3, fast=False, tool='verilator'):
     # build the simulator
-    dut = build_testbench(fast=fast)
+    dut = build_testbench(fast=fast, tool=tool)
 
     # create queues
     umi_in = UmiTxRx("in.q", "", fresh=True)
@@ -60,8 +60,8 @@ def main(n=3, fast=False):
             assert (txp.data == rxp.data).all()
 
 
-def build_testbench(fast=False):
-    dut = SbDut(default_main=True)
+def build_testbench(fast=False, tool='verilator'):
+    dut = SbDut(tool=tool, default_main=True)
 
     EX_DIR = Path('..').resolve()
 
@@ -82,6 +82,8 @@ if __name__ == '__main__':
         ' transactions to send into the FIFO during the test.')
     parser.add_argument('--fast', action='store_true', help='Do not build'
         ' the simulator binary if it has already been built.')
+    parser.add_argument('--tool', default='verilator', choices=['icarus', 'verilator'],
+        help='Name of the simulator to use.')
     args = parser.parse_args()
 
-    main(n=args.n, fast=args.fast)
+    main(n=args.n, fast=args.fast, tool=args.tool)

--- a/examples/umi_splitter/testbench.sv
+++ b/examples/umi_splitter/testbench.sv
@@ -4,12 +4,26 @@
 `default_nettype none
 
 module testbench (
-    input clk
+    `ifdef VERILATOR
+        input clk
+    `endif
 );
-
     parameter integer DW=256;
     parameter integer AW=64;
     parameter integer CW=32;
+
+    // clock
+    `ifndef VERILATOR
+
+        reg clk;
+        always begin
+            clk = 1'b0;
+            #5;
+            clk = 1'b1;
+            #5;
+        end
+
+    `endif
 
     // UMI Input
     wire umi_in_valid;

--- a/examples/umiram/Makefile
+++ b/examples/umiram/Makefile
@@ -3,9 +3,13 @@
 
 SBDIR := $(shell switchboard --path)
 
-.PHONY: python
-python:
-	./test.py --mode python
+.PHONY: verilator
+verilator:
+	./test.py --tool verilator
+
+.PHONY: icarus
+icarus:
+	./test.py --tool icarus
 
 .PHONY: cpp
 cpp: client

--- a/examples/umiram/test.py
+++ b/examples/umiram/test.py
@@ -83,8 +83,8 @@ def python_intf(umi):
     assert val2 == 0xCD
 
 
-def build_testbench(fast=False):
-    dut = SbDut('testbench', default_main=True, trace_type='fst')
+def build_testbench(fast=False, tool='verilator'):
+    dut = SbDut('testbench', tool=tool, default_main=True, trace_type='fst')
 
     EX_DIR = Path('..').resolve()
 
@@ -98,9 +98,9 @@ def build_testbench(fast=False):
     return dut
 
 
-def main(mode='python', fast=False):
+def main(mode='python', fast=False, tool='verilator'):
     # build the simulator
-    dut = build_testbench(fast=fast)
+    dut = build_testbench(fast=fast, tool=tool)
 
     # create queues
     umi = UmiTxRx('to_rtl.q', 'from_rtl.q', fresh=True)
@@ -118,9 +118,12 @@ def main(mode='python', fast=False):
 
 if __name__ == '__main__':
     parser = ArgumentParser()
-    parser.add_argument('--mode', default='python')
+    parser.add_argument('--mode', default='python', choices=['python', 'cpp'],
+        help='Programming language used for the test stimulus.')
     parser.add_argument('--fast', action='store_true', help='Do not build'
         ' the simulator binary if it has already been built.')
+    parser.add_argument('--tool', default='verilator', choices=['icarus', 'verilator'],
+        help='Name of the simulator to use.')
     args = parser.parse_args()
 
-    main(mode=args.mode, fast=args.fast)
+    main(mode=args.mode, fast=args.fast, tool=args.tool)

--- a/examples/umiram/testbench.sv
+++ b/examples/umiram/testbench.sv
@@ -4,8 +4,21 @@
 `default_nettype none
 
 module testbench (
-    input clk
+    `ifdef VERILATOR
+        input clk
+    `endif
 );
+    `ifndef VERILATOR
+
+        reg clk;
+        always begin
+            clk = 1'b0;
+            #5;
+            clk = 1'b1;
+            #5;
+        end
+
+    `endif
 
     parameter integer DW=256;
     parameter integer AW=64;


### PR DESCRIPTION
Now, RTL-based examples can be run with `make verilator` or `make icarus`.  `make` defaults to `make verilator`.  No drastic changes were needed to support this; it was mainly a matter of driving the clock in Verilog when the simulator is anything other than Verilator.

The only other issue I found was that the `udev_resp_data` port on `umiram` needed to be declared a `reg` because it is assigned in an `always` block.  I think that was just a mistake; it doesn't seem that there was a reason why it had to be a `wire`.

Intended to be merged with rebase.

