### PR TITLE
Add a link to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Switchboard
 
 [![Actions Status](https://github.com/zeroasiccorp/switchboard/actions/workflows/regression.yml/badge.svg?branch=main)](https://github.com/zeroasiccorp/switchboard/actions)
+[![Documentation Status](https://github.com/zeroasiccorp/switchboard/actions/workflows/documentation.yml/badge.svg?branch=main)](https://zeroasiccorp.github.io/switchboard/)
 
 Switchboard (SB) is a framework for communication between distinct hardware models, such as RTL simulations, RTL implemented on FPGAs, and fast SW models.  This makes it possible to simulate large hardware systems in a distributed fashion, using whatever models are available for the different components.
 


### PR DESCRIPTION
Testing: visit the readme here https://github.com/zeroasiccorp/switchboard/tree/sgh/docs-badge to see if the new badge renders properly and the link works.  I put a forward slash at the end of the documentation URL since that was needed for my own testing (possibly related to browser caching).  This PR is also a test of including the `Docs` action as a PR testing requirement.