### PR TITLE
Experimental support for Xyce co-simulation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ compile_flags.txt
 results.xml
 obj_dir
 .pytest_cache
+*.mt0
 
 # queues
 queue-*

--- a/examples/xyce/Makefile
+++ b/examples/xyce/Makefile
@@ -1,0 +1,17 @@
+# Copyright (c) 2024 Zero ASIC Corporation
+# This code is licensed under Apache License 2.0 (see LICENSE for details)
+
+.PHONY: verilator
+verilator:
+	./test.py --tool verilator
+
+.PHONY: icarus
+icarus:
+	./test.py --tool icarus
+
+.PHONY: clean
+clean:
+	rm -f queue-* *.q
+	rm -f *.mt0
+	rm -f *.vcd *.fst *.fst.hier
+	rm -rf obj_dir build

--- a/examples/xyce/rc.cir
+++ b/examples/xyce/rc.cir
@@ -1,0 +1,18 @@
+RC circuit
+
+* Copyright (c) 2024 Zero ASIC Corporation
+* This code is licensed under Apache License 2.0 (see LICENSE for details)
+
+* voltage input
+YDAC DAC0 in 0 simpleDAC
+.model simpleDAC DAC (tr=5e-9 tf=5e-9)
+
+Rin in out 10k
+Cout out 0 10p
+
+* voltage output
+.measure tran ADC0 EQN V(out)
+
+.TRAN 0 1
+
+.END

--- a/examples/xyce/test.py
+++ b/examples/xyce/test.py
@@ -31,4 +31,4 @@ if __name__ == '__main__':
         help='Period of the oversampling clock')
     args = parser.parse_args()
 
-    main(fast=args.fast, tool=args.tool)
+    main(fast=args.fast, period=args.period, tool=args.tool)

--- a/examples/xyce/test.py
+++ b/examples/xyce/test.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+# Example illustrating mixed-signal simulation
+
+# Copyright (c) 2024 Zero ASIC Corporation
+# This code is licensed under Apache License 2.0 (see LICENSE for details)
+
+from argparse import ArgumentParser
+from switchboard import SbDut
+
+
+def main(fast=False, tool='verilator'):
+    # build the simulator
+    dut = SbDut(tool=tool, default_main=True, xyce=True)
+    dut.input('testbench.sv')
+    dut.build(fast=fast)
+
+    # start chip simulation
+    chip = dut.simulate()
+
+    chip.wait()
+
+
+if __name__ == '__main__':
+    parser = ArgumentParser()
+    parser.add_argument('--fast', action='store_true', help='Do not build'
+        ' the simulator binary if it has already been built.')
+    parser.add_argument('--tool', default='verilator', choices=['icarus', 'verilator'],
+        help='Name of the simulator to use.')
+    args = parser.parse_args()
+
+    main(fast=args.fast, tool=args.tool)

--- a/examples/xyce/test.py
+++ b/examples/xyce/test.py
@@ -9,14 +9,14 @@ from argparse import ArgumentParser
 from switchboard import SbDut
 
 
-def main(fast=False, tool='verilator'):
+def main(fast=False, period=10e-9, tool='verilator'):
     # build the simulator
     dut = SbDut(tool=tool, default_main=True, xyce=True)
     dut.input('testbench.sv')
     dut.build(fast=fast)
 
     # start chip simulation
-    chip = dut.simulate()
+    chip = dut.simulate(period=period)
 
     chip.wait()
 
@@ -27,6 +27,8 @@ if __name__ == '__main__':
         ' the simulator binary if it has already been built.')
     parser.add_argument('--tool', default='verilator', choices=['icarus', 'verilator'],
         help='Name of the simulator to use.')
+    parser.add_argument('--period', type=float, default=10e-9,
+        help='Period of the oversampling clock')
     args = parser.parse_args()
 
     main(fast=args.fast, tool=args.tool)

--- a/examples/xyce/testbench.sv
+++ b/examples/xyce/testbench.sv
@@ -9,24 +9,21 @@ module testbench (
     // clock
 
     `ifndef VERILATOR
+        timeunit 1s;
+        timeprecision 1fs;
 
         real period = 10e-9;
-
-        integer ignore;
         initial begin
-            ignore = $value$plusargs("period=%f", period);
+            $value$plusargs("period=%f", period);
         end
-
-        // TODO: don't hardcode the timeunit
 
         reg clk;
         always begin
             clk = 1'b0;
-            #(0.5 * period * 1e9);
+            #(0.5 * period);
             clk = 1'b1;
-            #(0.5 * period * 1e9);
+            #(0.5 * period);
         end
-
     `endif
 
     xyce_intf xyce_intf_i ();

--- a/examples/xyce/testbench.sv
+++ b/examples/xyce/testbench.sv
@@ -1,0 +1,67 @@
+// Copyright (c) 2024 Zero ASIC Corporation
+// This code is licensed under Apache License 2.0 (see LICENSE for details)
+
+module testbench (
+    `ifdef VERILATOR
+        input clk
+    `endif
+);
+    // clock
+
+    `ifndef VERILATOR
+
+        reg clk;
+        always begin
+            clk = 1'b0;
+            #5;
+            clk = 1'b1;
+            #5;
+        end
+
+    `endif
+
+    xyce_intf xyce_intf_i ();
+
+    real in = 0.0;
+    real out = 0.0;
+
+    always @(clk) begin
+        xyce_intf_i.advance(5e-9);
+        xyce_intf_i.get("ADC0", out);
+    end
+
+    integer bits = 0;
+    integer count = 0;
+    always @(posedge clk) begin
+        if (count + 1 == 10) begin
+            count <= 0;
+            in = 1.0 - in;
+            xyce_intf_i.put("DAC0", in);
+            if (bits + 1 == 10) begin
+                $finish;
+            end else begin
+                bits <= bits + 1;
+            end
+        end else begin
+            count <= count + 1;
+        end
+    end
+
+    // Initialize 
+
+    initial begin
+        /* verilator lint_off IGNOREDRETURN */
+        xyce_intf_i.init("rc.cir");
+        /* verilator lint_on IGNOREDRETURN */
+    end
+
+    // Waveforms
+
+    initial begin
+        if ($test$plusargs("trace")) begin
+            $dumpfile("testbench.vcd");
+            $dumpvars(0, testbench);
+        end
+    end
+
+endmodule

--- a/examples/xyce/testbench.sv
+++ b/examples/xyce/testbench.sv
@@ -55,7 +55,7 @@ module testbench (
         xyce_intf_i.get("ADC0", out);
     end
 
-    // Initialize 
+    // Initialize
 
     initial begin
         /* verilator lint_off IGNOREDRETURN */

--- a/examples/xyce/testbench.sv
+++ b/examples/xyce/testbench.sv
@@ -12,16 +12,19 @@ module testbench (
 
         real period = 10e-9;
 
+        integer ignore;
         initial begin
-            $value$plusargs("period=%f", period);
+            ignore = $value$plusargs("period=%f", period);
         end
+
+        // TODO: don't hardcode the timeunit
 
         reg clk;
         always begin
             clk = 1'b0;
-            #(0.5 * period * (10.0 ** (-1.0 * $timeunit)));
+            #(0.5 * period * 1e9);
             clk = 1'b1;
-            #(0.5 * period * (10.0 ** (-1.0 * $timeunit)));
+            #(0.5 * period * 1e9);
         end
 
     `endif

--- a/examples/xyce/testbench.sv
+++ b/examples/xyce/testbench.sv
@@ -10,12 +10,18 @@ module testbench (
 
     `ifndef VERILATOR
 
+        real period = 10e-9;
+
+        initial begin
+            $value$plusargs("period=%f", period);
+        end
+
         reg clk;
         always begin
             clk = 1'b0;
-            #5;
+            #(0.5 * period * (10.0 ** (-1.0 * $timeunit)));
             clk = 1'b1;
-            #5;
+            #(0.5 * period * (10.0 ** (-1.0 * $timeunit)));
         end
 
     `endif
@@ -25,18 +31,12 @@ module testbench (
     real in = 0.0;
     real out = 0.0;
 
-    always @(clk) begin
-        xyce_intf_i.advance(5e-9);
-        xyce_intf_i.get("ADC0", out);
-    end
-
     integer bits = 0;
     integer count = 0;
     always @(posedge clk) begin
         if (count + 1 == 10) begin
             count <= 0;
             in = 1.0 - in;
-            xyce_intf_i.put("DAC0", in);
             if (bits + 1 == 10) begin
                 $finish;
             end else begin
@@ -45,6 +45,14 @@ module testbench (
         end else begin
             count <= count + 1;
         end
+    end
+
+    always @(in) begin
+        xyce_intf_i.put("DAC0", in);
+    end
+
+    always @(clk) begin
+        xyce_intf_i.get("ADC0", out);
     end
 
     // Initialize 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@
 from setuptools import setup, find_packages
 from pybind11.setup_helpers import Pybind11Extension, build_ext
 
-__version__ = "0.0.32"
+__version__ = "0.0.33"
 
 #################################################################################
 # parse_reqs, long_desc from https://github.com/siliconcompiler/siliconcompiler #

--- a/switchboard/cpp/xyce.hpp
+++ b/switchboard/cpp/xyce.hpp
@@ -2,8 +2,8 @@
 // This code is licensed under Apache License 2.0 (see LICENSE for details)
 
 #include <map>
-#include <vector>
 #include <string>
+#include <vector>
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -26,15 +26,11 @@ class XyceIntf {
 
     void init(std::string file) {
         // pointer to N_CIR_Xyce object
-        m_xyceObj = (void **) malloc( sizeof(void* [1]) );
+        m_xyceObj = (void**)malloc(sizeof(void* [1]));
 
         // xyce command
-        char *argList[] = {
-            (char*)("Xyce"),
-            (char*)("-quiet"),
-            (char*)file.c_str()
-        };
-        int argc = sizeof(argList)/sizeof(argList[0]);
+        char* argList[] = {(char*)("Xyce"), (char*)("-quiet"), (char*)file.c_str()};
+        int argc = sizeof(argList) / sizeof(argList[0]);
         char** argv = argList;
 
         // Open N_CIR_Xyce object
@@ -67,13 +63,8 @@ class XyceIntf {
         if (m_initialized) {
             std::string fullName = "YDAC!" + name;
 
-            xyce_updateTimeVoltagePairs(
-                m_xyceObj,
-                (char*)fullName.c_str(),
-                m_time[name].size(),
-                m_time[name].data(),
-                m_value[name].data()
-            );
+            xyce_updateTimeVoltagePairs(m_xyceObj, (char*)fullName.c_str(), m_time[name].size(),
+                m_time[name].data(), m_value[name].data());
         }
     }
 

--- a/switchboard/cpp/xyce.hpp
+++ b/switchboard/cpp/xyce.hpp
@@ -1,0 +1,99 @@
+// Copyright (c) 2024 Zero ASIC Corporation
+// This code is licensed under Apache License 2.0 (see LICENSE for details)
+
+#include <map>
+#include <vector>
+#include <string>
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <N_CIR_XyceCInterface.h>
+
+class XyceIntf {
+  public:
+    XyceIntf() {}
+
+    ~XyceIntf() {
+        if (m_opened) {
+            xyce_close(m_xyceObj);
+        }
+
+        if (m_xyceObj) {
+            free(m_xyceObj);
+        }
+    }
+
+    void init(std::string file) {
+        // pointer to N_CIR_Xyce object
+        m_xyceObj = (void **) malloc( sizeof(void* [1]) );
+
+        // xyce command
+        char *argList[] = {
+            (char*)("Xyce"),
+            (char*)("-quiet"),
+            (char*)file.c_str()
+        };
+        int argc = sizeof(argList)/sizeof(argList[0]);
+        char** argv = argList;
+
+        // Open N_CIR_Xyce object
+        xyce_open(m_xyceObj);
+        m_opened = true;
+
+        // Initialize N_CIR_Xyce object
+        xyce_initialize(m_xyceObj, argc, argv);
+        m_initialized = true;
+
+        // Simulate for a small amount of time
+        xyce_simulateUntil(m_xyceObj, 1e-10, &m_simTime);
+    }
+
+    void put(std::string name, double time, double value) {
+        if (!m_time.count(name)) {
+            m_time[name] = std::vector<double>();
+        }
+
+        m_time[name].push_back(time);
+
+        if (!m_value.count(name)) {
+            m_value[name] = std::vector<double>();
+        }
+
+        m_value[name].push_back(value);
+
+        // TODO: prune old values for higher performance?
+
+        if (m_initialized) {
+            std::string fullName = "YDAC!" + name;
+
+            xyce_updateTimeVoltagePairs(
+                m_xyceObj,
+                (char*)fullName.c_str(),
+                m_time[name].size(),
+                m_time[name].data(),
+                m_value[name].data()
+            );
+        }
+    }
+
+    void get(std::string name, double time, double* value) {
+        if (m_initialized) {
+            // advance simulation if necessary
+            if (time > m_simTime) {
+                int status = xyce_simulateUntil(m_xyceObj, time, &m_simTime);
+            }
+
+            // read out the value
+            xyce_obtainResponse(m_xyceObj, (char*)name.c_str(), value);
+        }
+    }
+
+  private:
+    void** m_xyceObj;
+    double m_simTime;
+    bool m_opened;
+    bool m_initialized;
+    std::map<std::string, std::vector<double>> m_time;
+    std::map<std::string, std::vector<double>> m_value;
+};

--- a/switchboard/dpi/xyce_dpi.cc
+++ b/switchboard/dpi/xyce_dpi.cc
@@ -1,0 +1,91 @@
+// Copyright (c) 2024 Zero ASIC Corporation
+// This code is licensed under Apache License 2.0 (see LICENSE for details)
+
+#include "svdpi.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <N_CIR_XyceCInterface.h>
+
+// function definitions
+#ifdef __cplusplus
+extern "C" {
+#endif
+extern void pi_sb_xyce_init(char* file);
+extern void pi_sb_xyce_advance(double dt);
+extern void pi_sb_xyce_put(char* name, double value);
+extern void pi_sb_xyce_get(char* name, double* val);
+#ifdef __cplusplus
+}
+#endif
+
+bool opened = false;
+bool initialized = false;
+static void** xyceObj = NULL;
+
+double sim_time = 0.0;
+
+void cleanupFunction() {
+    if (opened) {
+        xyce_close(xyceObj);
+    }
+
+    if (xyceObj) {
+        free(xyceObj);
+    }
+}
+
+void pi_sb_xyce_init(char* file) {
+    // pointer to N_CIR_Xyce object
+    xyceObj = (void **) malloc( sizeof(void* [1]) );
+    atexit(cleanupFunction);
+
+    // xyce command
+    char *argList[] = {
+        (char*)("Xyce"),
+        (char*)("-quiet"),
+        file
+    };
+    int argc = sizeof(argList)/sizeof(argList[0]);
+    char** argv = argList;
+
+    // Open N_CIR_Xyce object
+    xyce_open(xyceObj);
+    opened = true;
+
+    // Initialize N_CIR_Xyce object
+    xyce_initialize(xyceObj, argc, argv);
+    initialized = true;
+
+    // Simulate for a small amount of time
+    double actual_time;
+    xyce_simulateUntil(xyceObj, 1e-10, &actual_time);
+    sim_time = actual_time;
+}
+
+void pi_sb_xyce_advance(double dt){
+    if (initialized) {
+        double actual_time;
+        int status = xyce_simulateUntil(xyceObj, sim_time + dt, &actual_time);
+        sim_time = actual_time;
+    }
+}
+
+void pi_sb_xyce_put(char* name, double value) {
+    if (initialized) {
+        double timeArray [] = {sim_time};
+        double voltageArray [] = {value};
+
+        char fullName[100];
+        sprintf(fullName, "YDAC!%s", name);
+
+        xyce_updateTimeVoltagePairs(xyceObj, fullName, 1, timeArray, voltageArray);
+    }
+}
+
+void pi_sb_xyce_get(char* name, double* value) {
+    if (initialized) {
+        xyce_obtainResponse(xyceObj, name, value);
+    }
+}

--- a/switchboard/dpi/xyce_dpi.cc
+++ b/switchboard/dpi/xyce_dpi.cc
@@ -3,89 +3,34 @@
 
 #include "svdpi.h"
 
+#include <string>
+
 #include <stdio.h>
 #include <stdlib.h>
 
-#include <N_CIR_XyceCInterface.h>
+#include "xyce.hpp"
 
 // function definitions
 #ifdef __cplusplus
 extern "C" {
 #endif
 extern void pi_sb_xyce_init(char* file);
-extern void pi_sb_xyce_advance(double dt);
-extern void pi_sb_xyce_put(char* name, double value);
-extern void pi_sb_xyce_get(char* name, double* val);
+extern void pi_sb_xyce_put(char* name, double time, double value);
+extern void pi_sb_xyce_get(char* name, double time, double* val);
 #ifdef __cplusplus
 }
 #endif
 
-bool opened = false;
-bool initialized = false;
-static void** xyceObj = NULL;
-
-double sim_time = 0.0;
-
-void cleanupFunction() {
-    if (opened) {
-        xyce_close(xyceObj);
-    }
-
-    if (xyceObj) {
-        free(xyceObj);
-    }
-}
+XyceIntf x;
 
 void pi_sb_xyce_init(char* file) {
-    // pointer to N_CIR_Xyce object
-    xyceObj = (void **) malloc( sizeof(void* [1]) );
-    atexit(cleanupFunction);
-
-    // xyce command
-    char *argList[] = {
-        (char*)("Xyce"),
-        (char*)("-quiet"),
-        file
-    };
-    int argc = sizeof(argList)/sizeof(argList[0]);
-    char** argv = argList;
-
-    // Open N_CIR_Xyce object
-    xyce_open(xyceObj);
-    opened = true;
-
-    // Initialize N_CIR_Xyce object
-    xyce_initialize(xyceObj, argc, argv);
-    initialized = true;
-
-    // Simulate for a small amount of time
-    double actual_time;
-    xyce_simulateUntil(xyceObj, 1e-10, &actual_time);
-    sim_time = actual_time;
+    x.init(std::string(file));
 }
 
-void pi_sb_xyce_advance(double dt){
-    if (initialized) {
-        double actual_time;
-        int status = xyce_simulateUntil(xyceObj, sim_time + dt, &actual_time);
-        sim_time = actual_time;
-    }
+void pi_sb_xyce_put(char* name, double time, double value) {
+    x.put(std::string(name), time, value);
 }
 
-void pi_sb_xyce_put(char* name, double value) {
-    if (initialized) {
-        double timeArray [] = {sim_time};
-        double voltageArray [] = {value};
-
-        char fullName[100];
-        sprintf(fullName, "YDAC!%s", name);
-
-        xyce_updateTimeVoltagePairs(xyceObj, fullName, 1, timeArray, voltageArray);
-    }
-}
-
-void pi_sb_xyce_get(char* name, double* value) {
-    if (initialized) {
-        xyce_obtainResponse(xyceObj, name, value);
-    }
+void pi_sb_xyce_get(char* name, double time, double* value) {
+    x.get(std::string(name), time, value);
 }

--- a/switchboard/sbdut.py
+++ b/switchboard/sbdut.py
@@ -38,7 +38,8 @@ class SbDut(siliconcompiler.Chip):
         module: str = None,
         fpga: bool = False,
         xyce: bool = True,
-        period: float = 10e-9,
+        frequency: float = 100e6,
+        period: float = None,
         timeunit: str = None,
         timeprecision: str = None
     ):
@@ -102,7 +103,11 @@ class SbDut(siliconcompiler.Chip):
         self.trace_type = trace_type
         self.fpga = fpga
         self.xyce = xyce
+
+        if (period is None) and (frequency is not None):
+            period = 1 / frequency
         self.period = period
+
         self.timeunit = timeunit
         self.timeprecision = timeprecision
 
@@ -259,7 +264,8 @@ class SbDut(siliconcompiler.Chip):
         extra_args=None,
         cwd: str = None,
         trace: bool = None,
-        period: float = None
+        period: float = None,
+        frequency: float = None
     ) -> subprocess.Popen:
         """
         Parameters
@@ -300,6 +306,9 @@ class SbDut(siliconcompiler.Chip):
 
         if trace is None:
             trace = self.trace
+
+        if (period is None) and (frequency is not None):
+            period = 1 / frequency
 
         if period is None:
             period = self.period

--- a/switchboard/sbdut.py
+++ b/switchboard/sbdut.py
@@ -36,7 +36,8 @@ class SbDut(siliconcompiler.Chip):
         trace_type: str = 'vcd',
         module: str = None,
         fpga: bool = False,
-        xyce: bool = True
+        xyce: bool = True,
+        period: float = 10e-9
     ):
         """
         Parameters
@@ -68,6 +69,10 @@ class SbDut(siliconcompiler.Chip):
 
         xyce: bool, optional
             If True, compile for xyce co-simulation.
+
+        period: float, optional
+            If provided, the default period of the clock generated in the testbench,
+            in seconds.
         """
         # call the super constructor
 
@@ -94,6 +99,7 @@ class SbDut(siliconcompiler.Chip):
         self.trace_type = trace_type
         self.fpga = fpga
         self.xyce = xyce
+        self.period = period
 
         # simulator-agnostic settings
 
@@ -236,7 +242,8 @@ class SbDut(siliconcompiler.Chip):
         args=None,
         extra_args=None,
         cwd: str = None,
-        trace: bool = None
+        trace: bool = None,
+        period: float = None
     ) -> subprocess.Popen:
         """
         Parameters
@@ -258,6 +265,10 @@ class SbDut(siliconcompiler.Chip):
 
         trace: bool, optional
             If true, a waveform dump file will be produced
+
+        period: float, optional
+            If provided, the period of the clock generated in the testbench,
+            in seconds.
         """
 
         # set defaults
@@ -274,6 +285,9 @@ class SbDut(siliconcompiler.Chip):
         if trace is None:
             trace = self.trace
 
+        if period is None:
+            period = self.period
+
         # build the simulation if necessary
 
         sim = self.build(cwd=cwd, fast=True)
@@ -285,6 +299,11 @@ class SbDut(siliconcompiler.Chip):
 
         if trace and ('trace' not in plusargs) and ('+trace' not in args):
             plusargs.append('trace')
+
+        if ((period is not None)
+            and ('period' not in plusargs)
+            and not any(elem.startswith('+period') for elem in args)):
+            plusargs.append(('period', period))
 
         # run the simulation
 

--- a/switchboard/sbdut.py
+++ b/switchboard/sbdut.py
@@ -37,7 +37,7 @@ class SbDut(siliconcompiler.Chip):
         trace_type: str = 'vcd',
         module: str = None,
         fpga: bool = False,
-        xyce: bool = True,
+        xyce: bool = False,
         frequency: float = 100e6,
         period: float = None,
         timeunit: str = None,

--- a/switchboard/verilator/testbench.cc
+++ b/switchboard/verilator/testbench.cc
@@ -11,9 +11,9 @@
 #include <memory>
 
 // For changing the clock period
+#include <cmath>
 #include <iostream>
 #include <string>
-#include <cmath>
 
 // Include common routines
 #include <verilated.h>
@@ -66,8 +66,7 @@ int main(int argc, char** argv, char** env) {
         // the prefix, and the argument must start with the prefix,
         // ignoring the last character of the prefix, which can be
         // anything (typically "=" or "+")
-        if ((full.size() >= (len + 1))
-            && (full.substr(0, len - 1) == prefix.substr(0, len - 1))) {
+        if ((full.size() >= (len + 1)) && (full.substr(0, len - 1) == prefix.substr(0, len - 1))) {
             std::string rest = std::string(flag).substr(len);
             period = std::stod(rest);
         }

--- a/switchboard/verilog/sim/xyce_intf.sv
+++ b/switchboard/verilog/sim/xyce_intf.sv
@@ -4,13 +4,15 @@
 // This code is licensed under Apache License 2.0 (see LICENSE for details)
 
 module xyce_intf;
-    // TODO: don't hardcode the timeunit
+    timeprecision 1fs;
 
     `ifdef __ICARUS__
         `define SB_EXT_FUNC(x) $``x``
         `define SB_START_FUNC task
         `define SB_END_FUNC endtask
-        `define SB_ABSTIME ($realtime * 1.0e-9)
+
+        timeunit 1s;
+        `define SB_ABSTIME ($realtime)
     `else
         `define SB_EXT_FUNC(x) x
         `define SB_START_FUNC function void

--- a/switchboard/verilog/sim/xyce_intf.sv
+++ b/switchboard/verilog/sim/xyce_intf.sv
@@ -4,14 +4,18 @@
 // This code is licensed under Apache License 2.0 (see LICENSE for details)
 
 module xyce_intf;
+    // TODO: don't hardcode the timeunit
+
     `ifdef __ICARUS__
         `define SB_EXT_FUNC(x) $``x``
         `define SB_START_FUNC task
         `define SB_END_FUNC endtask
+        `define SB_ABSTIME ($realtime * 1.0e-9)
     `else
         `define SB_EXT_FUNC(x) x
         `define SB_START_FUNC function void
         `define SB_END_FUNC endfunction
+        `define SB_ABSTIME ($realtime/1s)
 
         import "DPI-C" function void pi_sb_xyce_init (input string file);
         import "DPI-C" function void pi_sb_xyce_put (
@@ -34,13 +38,13 @@ module xyce_intf;
 
    `SB_START_FUNC put(input string name, input real value);
         /* verilator lint_off IGNOREDRETURN */
-        `SB_EXT_FUNC(pi_sb_xyce_put)(name, $realtime * (10.0**($timeunit)), value);
+        `SB_EXT_FUNC(pi_sb_xyce_put)(name, `SB_ABSTIME, value);
         /* verilator lint_on IGNOREDRETURN */
     `SB_END_FUNC
 
    `SB_START_FUNC get(input string name, output real value);
         /* verilator lint_off IGNOREDRETURN */
-        `SB_EXT_FUNC(pi_sb_xyce_get)(name, $realtime * (10.0**($timeunit)), value);
+        `SB_EXT_FUNC(pi_sb_xyce_get)(name, `SB_ABSTIME, value);
         /* verilator lint_on IGNOREDRETURN */
     `SB_END_FUNC
 
@@ -49,5 +53,6 @@ module xyce_intf;
     `undef SB_EXT_FUNC
     `undef SB_START_FUNC
     `undef SB_END_FUNC
+    `undef SB_ABSTIME
 
 endmodule

--- a/switchboard/verilog/sim/xyce_intf.sv
+++ b/switchboard/verilog/sim/xyce_intf.sv
@@ -27,7 +27,7 @@ module xyce_intf;
         );
         import "DPI-C" function void pi_sb_xyce_get (
             input string name,
-            input real t, 
+            input real t,
             output real value
         );
     `endif

--- a/switchboard/verilog/sim/xyce_intf.sv
+++ b/switchboard/verilog/sim/xyce_intf.sv
@@ -14,9 +14,16 @@ module xyce_intf;
         `define SB_END_FUNC endfunction
 
         import "DPI-C" function void pi_sb_xyce_init (input string file);
-        import "DPI-C" function void pi_sb_xyce_advance (input real dt);
-        import "DPI-C" function void pi_sb_xyce_put (input string name, input real value);
-        import "DPI-C" function void pi_sb_xyce_get (input string name, output real value);
+        import "DPI-C" function void pi_sb_xyce_put (
+            input string name,
+            input real t,
+            input real value
+        );
+        import "DPI-C" function void pi_sb_xyce_get (
+            input string name,
+            input real t, 
+            output real value
+        );
     `endif
 
    `SB_START_FUNC init(input string file);
@@ -25,21 +32,15 @@ module xyce_intf;
         /* verilator lint_on IGNOREDRETURN */
     `SB_END_FUNC
 
-   `SB_START_FUNC advance(input real dt);
-        /* verilator lint_off IGNOREDRETURN */
-        `SB_EXT_FUNC(pi_sb_xyce_advance)(dt);
-        /* verilator lint_on IGNOREDRETURN */
-    `SB_END_FUNC
-
    `SB_START_FUNC put(input string name, input real value);
         /* verilator lint_off IGNOREDRETURN */
-        `SB_EXT_FUNC(pi_sb_xyce_put)(name, value);
+        `SB_EXT_FUNC(pi_sb_xyce_put)(name, $realtime * (10.0**($timeunit)), value);
         /* verilator lint_on IGNOREDRETURN */
     `SB_END_FUNC
 
    `SB_START_FUNC get(input string name, output real value);
         /* verilator lint_off IGNOREDRETURN */
-        `SB_EXT_FUNC(pi_sb_xyce_get)(name, value);
+        `SB_EXT_FUNC(pi_sb_xyce_get)(name, $realtime * (10.0**($timeunit)), value);
         /* verilator lint_on IGNOREDRETURN */
     `SB_END_FUNC
 

--- a/switchboard/verilog/sim/xyce_intf.sv
+++ b/switchboard/verilog/sim/xyce_intf.sv
@@ -1,0 +1,52 @@
+// Module for interfacing with Xyce analog simulation
+
+// Copyright (c) 2024 Zero ASIC Corporation
+// This code is licensed under Apache License 2.0 (see LICENSE for details)
+
+module xyce_intf;
+    `ifdef __ICARUS__
+        `define SB_EXT_FUNC(x) $``x``
+        `define SB_START_FUNC task
+        `define SB_END_FUNC endtask
+    `else
+        `define SB_EXT_FUNC(x) x
+        `define SB_START_FUNC function void
+        `define SB_END_FUNC endfunction
+
+        import "DPI-C" function void pi_sb_xyce_init (input string file);
+        import "DPI-C" function void pi_sb_xyce_advance (input real dt);
+        import "DPI-C" function void pi_sb_xyce_put (input string name, input real value);
+        import "DPI-C" function void pi_sb_xyce_get (input string name, output real value);
+    `endif
+
+   `SB_START_FUNC init(input string file);
+        /* verilator lint_off IGNOREDRETURN */
+        `SB_EXT_FUNC(pi_sb_xyce_init)(file);
+        /* verilator lint_on IGNOREDRETURN */
+    `SB_END_FUNC
+
+   `SB_START_FUNC advance(input real dt);
+        /* verilator lint_off IGNOREDRETURN */
+        `SB_EXT_FUNC(pi_sb_xyce_advance)(dt);
+        /* verilator lint_on IGNOREDRETURN */
+    `SB_END_FUNC
+
+   `SB_START_FUNC put(input string name, input real value);
+        /* verilator lint_off IGNOREDRETURN */
+        `SB_EXT_FUNC(pi_sb_xyce_put)(name, value);
+        /* verilator lint_on IGNOREDRETURN */
+    `SB_END_FUNC
+
+   `SB_START_FUNC get(input string name, output real value);
+        /* verilator lint_off IGNOREDRETURN */
+        `SB_EXT_FUNC(pi_sb_xyce_get)(name, value);
+        /* verilator lint_on IGNOREDRETURN */
+    `SB_END_FUNC
+
+    // clean up macros
+
+    `undef SB_EXT_FUNC
+    `undef SB_START_FUNC
+    `undef SB_END_FUNC
+
+endmodule

--- a/switchboard/vpi/xyce_vpi.cc
+++ b/switchboard/vpi/xyce_vpi.cc
@@ -22,7 +22,7 @@ PLI_INT32 pi_sb_xyce_init(PLI_BYTE8* userdata) {
         vpiHandle systfref;
         systfref = vpi_handle(vpiSysTfCall, NULL);
         args_iter = vpi_iterate(vpiArgument, systfref);
-        for (size_t i = 0; i < 3; i++) {
+        for (size_t i = 0; i < 1; i++) {
             argh.push_back(vpi_scan(args_iter));
         }
     }
@@ -32,7 +32,7 @@ PLI_INT32 pi_sb_xyce_init(PLI_BYTE8* userdata) {
     {
         t_vpi_value argval;
         argval.format = vpiStringVal;
-        vpi_get_value(argh[1], &argval);
+        vpi_get_value(argh[0], &argval);
         file = std::string(argval.value.str);
     }
 
@@ -65,7 +65,7 @@ PLI_INT32 pi_sb_xyce_put(PLI_BYTE8* userdata) {
     {
         t_vpi_value argval;
         argval.format = vpiStringVal;
-        vpi_get_value(argh[1], &argval);
+        vpi_get_value(argh[0], &argval);
         name = std::string(argval.value.str);
     }
 
@@ -74,7 +74,7 @@ PLI_INT32 pi_sb_xyce_put(PLI_BYTE8* userdata) {
     {
         t_vpi_value argval;
         argval.format = vpiRealVal;
-        vpi_get_value(argh[2], &argval);
+        vpi_get_value(argh[1], &argval);
         time = argval.value.real;
     }
 
@@ -83,7 +83,7 @@ PLI_INT32 pi_sb_xyce_put(PLI_BYTE8* userdata) {
     {
         t_vpi_value argval;
         argval.format = vpiRealVal;
-        vpi_get_value(argh[3], &argval);
+        vpi_get_value(argh[2], &argval);
         value = argval.value.real;
     }
 
@@ -116,7 +116,7 @@ PLI_INT32 pi_sb_xyce_get(PLI_BYTE8* userdata) {
     {
         t_vpi_value argval;
         argval.format = vpiStringVal;
-        vpi_get_value(argh[1], &argval);
+        vpi_get_value(argh[0], &argval);
         name = std::string(argval.value.str);
     }
 
@@ -125,7 +125,7 @@ PLI_INT32 pi_sb_xyce_get(PLI_BYTE8* userdata) {
     {
         t_vpi_value argval;
         argval.format = vpiRealVal;
-        vpi_get_value(argh[2], &argval);
+        vpi_get_value(argh[1], &argval);
         time = argval.value.real;
     }
 
@@ -138,7 +138,7 @@ PLI_INT32 pi_sb_xyce_get(PLI_BYTE8* userdata) {
         t_vpi_value argval;
         argval.format = vpiRealVal;
         argval.value.real = value;
-        vpi_put_value(argh[3], &argval, NULL, vpiNoDelay);
+        vpi_put_value(argh[2], &argval, NULL, vpiNoDelay);
     }
 
     // clean up

--- a/switchboard/vpi/xyce_vpi.cc
+++ b/switchboard/vpi/xyce_vpi.cc
@@ -1,0 +1,238 @@
+// Copyright (c) 2024 Zero ASIC Corporation
+// This code is licensed under Apache License 2.0 (see LICENSE for details)
+
+#include <vpi_user.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <N_CIR_XyceCInterface.h>
+
+bool opened = false;
+bool initialized = false;
+static void** xyceObj = NULL;
+
+double sim_time = 0.0;
+
+void cleanupFunction() {
+    if (opened) {
+        xyce_close(xyceObj);
+    }
+
+    if (xyceObj) {
+        free(xyceObj);
+    }
+}
+
+PLI_INT32 pi_sb_xyce_init(PLI_BYTE8* userdata) {
+    (void)userdata; // unused
+
+    // get arguments
+    vpiHandle args_iter;
+    std::vector<vpiHandle> argh;
+    {
+        vpiHandle systfref;
+        systfref = vpi_handle(vpiSysTfCall, NULL);
+        args_iter = vpi_iterate(vpiArgument, systfref);
+        for (size_t i = 0; i < 3; i++) {
+            argh.push_back(vpi_scan(args_iter));
+        }
+    }
+
+    // get file
+    char* file;
+    {
+        t_vpi_value argval;
+        argval.format = vpiStringVal;
+        vpi_get_value(argh[1], &argval);
+        file = argval.value.str;
+    }
+
+    // pointer to N_CIR_Xyce object
+    xyceObj = (void **) malloc( sizeof(void* [1]) );
+    atexit(cleanupFunction);
+
+    // xyce command
+    char *argList[] = {
+        (char*)("Xyce"),
+        (char*)("-quiet"),
+        file
+    };
+    int argc = sizeof(argList)/sizeof(argList[0]);
+    char** argv = argList;
+
+    // Open N_CIR_Xyce object
+    xyce_open(xyceObj);
+    opened = true;
+
+    // Initialize N_CIR_Xyce object
+    xyce_initialize(xyceObj, argc, argv);
+    initialized = true;
+
+    // Simulate for a small amount of time
+    double actual_time;
+    xyce_simulateUntil(xyceObj, 1e-10, &actual_time);
+    sim_time = actual_time;
+
+    // clean up
+    vpi_free_object(args_iter);
+
+    // return value unused?
+    return 0;
+}
+
+PLI_INT32 pi_sb_xyce_advance(PLI_BYTE8* userdata){
+    (void)userdata; // unused
+
+    // get arguments
+    vpiHandle args_iter;
+    std::vector<vpiHandle> argh;
+    {
+        vpiHandle systfref;
+        systfref = vpi_handle(vpiSysTfCall, NULL);
+        args_iter = vpi_iterate(vpiArgument, systfref);
+        for (size_t i = 0; i < 3; i++) {
+            argh.push_back(vpi_scan(args_iter));
+        }
+    }
+
+    // get dt
+    double dt;
+    {
+        t_vpi_value argval;
+        argval.format = vpiRealVal;
+        vpi_get_value(argh[1], &argval);
+        file = argval.value.real;
+    }
+
+    if (initialized) {
+        double actual_time;
+        int status = xyce_simulateUntil(xyceObj, sim_time + dt, &actual_time);
+        sim_time = actual_time;
+    }
+
+    // clean up
+    vpi_free_object(args_iter);
+
+    // return value unused?
+    return 0;
+}
+
+PLI_INT32 pi_sb_xyce_put(PLI_BYTE8* userdata) {
+    (void)userdata; // unused
+
+    // get arguments
+    vpiHandle args_iter;
+    std::vector<vpiHandle> argh;
+    {
+        vpiHandle systfref;
+        systfref = vpi_handle(vpiSysTfCall, NULL);
+        args_iter = vpi_iterate(vpiArgument, systfref);
+        for (size_t i = 0; i < 3; i++) {
+            argh.push_back(vpi_scan(args_iter));
+        }
+    }
+
+    // get name
+    char* name;
+    {
+        t_vpi_value argval;
+        argval.format = vpiStringVal;
+        vpi_get_value(argh[1], &argval);
+        name = argval.value.str;
+    }
+
+    // get value
+    double value;
+    {
+        t_vpi_value argval;
+        argval.format = vpiRealVal;
+        vpi_get_value(argh[2], &argval);
+        value = argval.value.real;
+    }
+
+    if (initialized) {
+        double timeArray [] = {sim_time};
+        double voltageArray [] = {value};
+
+        char fullName[100];
+        sprintf(fullName, "YDAC!%s", name);
+
+        xyce_updateTimeVoltagePairs(xyceObj, fullName, 1, timeArray, voltageArray);
+    }
+
+    // clean up
+    vpi_free_object(args_iter);
+
+    // return value unused?
+    return 0;
+}
+
+PLI_INT32 pi_sb_xyce_get(PLI_BYTE8* userdata) {
+    (void)userdata; // unused
+
+    // get arguments
+    vpiHandle args_iter;
+    std::vector<vpiHandle> argh;
+    {
+        vpiHandle systfref;
+        systfref = vpi_handle(vpiSysTfCall, NULL);
+        args_iter = vpi_iterate(vpiArgument, systfref);
+        for (size_t i = 0; i < 3; i++) {
+            argh.push_back(vpi_scan(args_iter));
+        }
+    }
+
+    // get name
+    char* name;
+    {
+        t_vpi_value argval;
+        argval.format = vpiStringVal;
+        vpi_get_value(argh[1], &argval);
+        name = argval.value.str;
+    }
+
+    double value;
+    if (initialized) {
+        xyce_obtainResponse(xyceObj, name, &value);
+    }
+
+    // put value
+    {
+        t_vpi_value argval;
+        argval.format = vpiRealVal;
+        argval.value.real = value;
+        vpi_put_value(argh[2], &argval, NULL, vpiNoDelay);
+    }
+
+    // clean up
+    vpi_free_object(args_iter);
+
+    // return value unused?
+    return 0;
+}
+
+// macro that creates a function to register PLI functions
+
+#define VPI_REGISTER_FUNC_NAME(name) register_##name
+#define VPI_REGISTER_FUNC(name)                                                                    \
+    void VPI_REGISTER_FUNC_NAME(name)(void) {                                                      \
+        s_vpi_systf_data data = {vpiSysTask, 0, (char*)("$" #name), name, 0, 0, 0};                \
+                                                                                                   \
+        vpi_register_systf(&data);                                                                 \
+    }
+
+// create the PLI registration functions using this macro
+
+VPI_REGISTER_FUNC(pi_sb_xyce_init)
+VPI_REGISTER_FUNC(pi_sb_xyce_advance)
+VPI_REGISTER_FUNC(pi_sb_xyce_put)
+VPI_REGISTER_FUNC(pi_sb_xyce_get)
+
+void (*vlog_startup_routines[])(void) = {
+    VPI_REGISTER_FUNC_NAME(pi_sb_xyce_init),
+    VPI_REGISTER_FUNC_NAME(pi_sb_xyce_advance),
+    VPI_REGISTER_FUNC_NAME(pi_sb_xyce_put),
+    VPI_REGISTER_FUNC_NAME(pi_sb_xyce_get),
+    0 // last entry must be 0
+};

--- a/switchboard/vpi/xyce_vpi.cc
+++ b/switchboard/vpi/xyce_vpi.cc
@@ -165,8 +165,7 @@ VPI_REGISTER_FUNC(pi_sb_xyce_put)
 VPI_REGISTER_FUNC(pi_sb_xyce_get)
 
 void (*vlog_startup_routines[])(void) = {
-    VPI_REGISTER_FUNC_NAME(pi_sb_xyce_init),
-    VPI_REGISTER_FUNC_NAME(pi_sb_xyce_put),
+    VPI_REGISTER_FUNC_NAME(pi_sb_xyce_init), VPI_REGISTER_FUNC_NAME(pi_sb_xyce_put),
     VPI_REGISTER_FUNC_NAME(pi_sb_xyce_get),
     0 // last entry must be 0
 };

--- a/switchboard/xyce.py
+++ b/switchboard/xyce.py
@@ -1,0 +1,27 @@
+# Utilities for working with Xyce
+
+# Copyright (c) 2024 Zero ASIC Corporation
+# This code is licensed under Apache License 2.0 (see LICENSE for details)
+
+
+def xyce_flags():
+    import shutil
+    from pathlib import Path
+
+    xyce = shutil.which('Xyce')
+
+    if not xyce:
+        raise RuntimeError('Xyce install not found')
+
+    xyce_prefix = Path(xyce).parent.parent
+
+    ldflags = [
+        f'-L{xyce_prefix / "lib"}',
+        '-lxycecinterface'
+    ]
+
+    cincludes = [
+        f'{xyce_prefix / "include"}'
+    ]
+
+    return cincludes, ldflags


### PR DESCRIPTION
This PR adds initial support for mixed-signal co-simulation using Xyce, making use of `lxycecinterface` (https://xyce.sandia.gov/files/xyce/AppNote-MixedSignal.pdf).

See [examples/xyce](examples/xyce) for an example of how to use this feature.  In short:
1. Instantiate `xyce_intf` in your RTL.
2. Use `xyce_intf_inst.init("/path/to/circuit.cir")` in an `initial` block to point Xyce to the circuit you want to simulate.
    * In that circuit, use `YDAC DACNAME net 0 dacModel` instances to drive signals in the RTL -> Xyce direction.  `DACNAME` is the name you'll use to drive the DAC from RTL.  It must be all-caps.
    * Use `.measure tran ADCNAME EQN V(net)` statements for the Xyce -> RTL direction.  `ADCNAME` is the name you'll use to read the ADC from RTL.  All-caps is optional in this direction.
3. Use `xyce_intf_inst.put("DACNAME", signalValue)` to write `real` RTL signal `signalValue` number to the DAC `DACNAME` in the Xyce simulation.  Note that the DAC input is a real number that directly represents voltage (no quantization)
4. Use `xyce_intf_inst.get("ADCNAME", signalValue)` to read a real number from the ADC `ADCNAME` in the Xyce simulation into the RTL `real` variable `signalValue`.  Note that the ADC output is a real number that directly represents voltage (no quantization)
5. When you instantiate `SbDut`, set `xyce=True`.

Recommended pattern for using `put()`:

```systemverilog
real voh, vol, analogSignal;
wire digitalSignal;
always @(digitalSignal) begin
    analogSignal = digitalSignal ? voh : vol;
    xyce_intf_inst.put("DACNAME", analogSignal);
end
```

Recommended pattern for using `get()`:

```systemverilog
wire samplingClock;
real vih, vil, analogSignal;
reg digitalSignal;
always @(posedge samplingClock) begin
    xyce_intf_inst.get("ADCNAME", analogSignal);
    if (analogSignal >= vih) begin
        digitalSignal = 1;
    end else if (analogSignal <= vil) begin
        digitalSignal = 0;    
    end
end
```

Please note: this interface is experimental and may change in subsequent releases.