### PR TITLE
Fix bug in passing custom arguments to simulations

### DIFF
--- a/examples/args/Makefile
+++ b/examples/args/Makefile
@@ -1,0 +1,16 @@
+# Copyright (c) 2024 Zero ASIC Corporation
+# This code is licensed under Apache License 2.0 (see LICENSE for details)
+
+.PHONY: verilator
+verilator:
+	./test.py --tool verilator
+
+.PHONY: icarus
+verilator:
+	./test.py --tool icarus
+
+.PHONY: clean
+clean:
+	rm -f queue-* *.q *.o *.vpi
+	rm -f *.vcd *.fst *.fst.hier
+	rm -rf obj_dir build

--- a/examples/args/test.py
+++ b/examples/args/test.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+
+# Example showing how to pass a custom argument to a simulation binary
+
+# Copyright (c) 2024 Zero ASIC Corporation
+# This code is licensed under Apache License 2.0 (see LICENSE for details)
+
+from argparse import ArgumentParser, REMAINDER
+from switchboard import SbDut
+
+
+def main(fast=False, tool='verilator', args=None):
+    dut = SbDut(tool=tool, default_main=True)
+    dut.input('testbench.sv')
+    dut.build(fast=fast)
+    dut.simulate(args=args).wait()
+
+
+if __name__ == '__main__':
+    parser = ArgumentParser()
+    parser.add_argument('--fast', action='store_true', help='Do not build'
+        ' the simulator binary if it has already been built.')
+    parser.add_argument('--tool', default='verilator', choices=['icarus', 'verilator'],
+        help='Name of the simulator to use.')
+    parser.add_argument('args', nargs=REMAINDER,
+        help='Arguments to pass directly to the simulation.')
+    args = parser.parse_args()
+
+    main(fast=args.fast, tool=args.tool, args=args.args)

--- a/examples/args/testbench.sv
+++ b/examples/args/testbench.sv
@@ -1,0 +1,39 @@
+// Copyright (c) 2024 Zero ASIC Corporation
+// This code is licensed under Apache License 2.0 (see LICENSE for details)
+
+module testbench (
+    `ifdef VERILATOR
+        input clk
+    `endif
+);
+    // clock
+
+    `ifndef VERILATOR
+
+        reg clk;
+        always begin
+            clk = 1'b0;
+            #5;
+            clk = 1'b1;
+            #5;
+        end
+
+    `endif
+
+    integer a=0, b=0;
+
+    initial begin
+        $value$plusargs("a+%d", a);
+        $value$plusargs("b+%d", b);
+
+        $write("a: %0d\n", a);
+        $write("b: %0d\n", b);
+
+        $write("$random: %0d\n", $random);
+        $write("$random: %0d\n", $random);
+        $write("$random: %0d\n", $random);
+
+        $finish;
+    end
+
+endmodule

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@
 from setuptools import setup, find_packages
 from pybind11.setup_helpers import Pybind11Extension, build_ext
 
-__version__ = "0.0.33"
+__version__ = "0.0.34"
 
 #################################################################################
 # parse_reqs, long_desc from https://github.com/siliconcompiler/siliconcompiler #

--- a/switchboard/sbdut.py
+++ b/switchboard/sbdut.py
@@ -354,7 +354,7 @@ class SbDut(siliconcompiler.Chip):
                 sim,
                 plusargs=plusargs,
                 modules=modules,
-                extra_args=extra_args
+                extra_args=args + extra_args
             )
         else:
             # make sure that the simulator was built with tracing enabled
@@ -363,10 +363,16 @@ class SbDut(siliconcompiler.Chip):
                     '  Please set trace=True in the SbDut and try again.')
 
             if self.tool == 'verilator':
-                p = verilator_run(sim, plusargs=plusargs)
+                p = verilator_run(
+                    sim,
+                    plusargs=plusargs,
+                    args=args
+                )
             else:
-                args = plusargs_to_args(plusargs)
-                p = binary_run(sim, args=args)
+                p = binary_run(
+                    sim,
+                    args=plusargs_to_args(plusargs) + args
+                )
 
         # return a Popen object that one can wait() on
 


### PR DESCRIPTION
`SbDut.simulate(..., args=...)` should now work as expected, with the arguments specified in `args` passed directly to the simulation binary.