### PR TITLE
Allow instantiations of end caps with different DW values

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@
 from setuptools import setup, find_packages
 from pybind11.setup_helpers import Pybind11Extension, build_ext
 
-__version__ = "0.0.34"
+__version__ = "0.0.35"
 
 #################################################################################
 # parse_reqs, long_desc from https://github.com/siliconcompiler/siliconcompiler #


### PR DESCRIPTION
Previously, there was an issue in which creating multiple instances of `queue_to_sb_sim` or `sb_to_queue_sim` with different `DW` values would result in an error during Verilator compilation, when using recent Verilator versions.