### PR TITLE
update wheels and add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"
+  # Maintain dependencies for Python
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      python-packages:
+        patterns:
+          - "*"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [cp37*, cp38*, cp39*, cp310*, cp311*]
+        python-version: [cp37, cp38, cp39, cp310, cp311]
         platform:
           - os: ubuntu-latest
             arch: x86_64
@@ -50,7 +50,7 @@ jobs:
     - uses: pypa/cibuildwheel@v2.12.1
       env:
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-        CIBW_BUILD: ${{ matrix.python-version }}
+        CIBW_BUILD: ${{ matrix.python-version }}*
         CIBW_SKIP: "pp* *win32 *i686 *-musllinux_*"
         CIBW_ARCHS_MACOS: x86_64 arm64
         CIBW_TEST_SKIP: "*_arm64"
@@ -59,10 +59,10 @@ jobs:
     # been created, even if cibuildwheel action fails
     - name: Upload wheels
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: wheelhouse/*.whl
-        name: switchboard
+        name: switchboard-${{ matrix.python-version }}-${{ matrix.platform.os }}-${{ matrix.platform.arch }}
         retention-days: 14
 
   publish:
@@ -71,9 +71,10 @@ jobs:
     if: github.event_name == 'release' && github.event.action == 'published' && !contains(github.event.release.body, 'NOPUBLISH')
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
-        name: switchboard
+        pattern: switchboard-*
+        merge-multiple: true
         path: dist
 
     - uses: pypa/gh-action-pypi-publish@v1.4.2


### PR DESCRIPTION
Adds:
- dependabot for github actions and pip requirements (https://github.com/siliconcompiler/siliconcompiler/blob/main/.github/dependabot.yml)

Updates:
- wheels build to match [siliconcompiler](https://github.com/siliconcompiler/siliconcompiler/blob/main/.github/workflows/wheels.yml) to account for breaking changes to upload and download actions. (https://github.com/zeroasiccorp/switchboard/actions/runs/7672730305)
