### PR TITLE
Runtime error for unexpected UMI responses + option to demote to a warning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@
 from setuptools import setup, find_packages
 from pybind11.setup_helpers import Pybind11Extension, build_ext
 
-__version__ = "0.0.35"
+__version__ = "0.0.36"
 
 #################################################################################
 # parse_reqs, long_desc from https://github.com/siliconcompiler/siliconcompiler #


### PR DESCRIPTION
This PR changes the default behavior of switchboard to error out when there is an unexpected UMI response.  This should make it easier to see where problems are coming from, and will prevent these issues from getting lost in output logs.

To demote this behavior to a warning, set `error=False` when you instantiate `UmiTxRx`.  You can also set `error=False` for individual `read`, `write`, and `atomic` operations; this overrides the default set when instantiating `UmiTxRx`.

Example 1
```python
umi = UmiTxRx(...)
umi.write(...)  # will error out if there is an unexpected response
umi.write(..., error=False)  # will only print a warning if there is an unexpected response
```

Example 2
```python
umi = UmiTxRx(..., error=False)
umi.read(...)  # will only print a warning if there is an unexpected response
umi.read(..., error=True)  # will error out if there is an unexpected response
```