### PR TITLE
Enable BLKSEQ by default for Verilator

### DIFF
--- a/examples/common/verilog/umiram.sv
+++ b/examples/common/verilog/umiram.sv
@@ -129,6 +129,8 @@ module umiram #(
 
     integer i;
 
+    /* verilator lint_off BLKSEQ */
+
     function [ATOMIC_WIDTH-1:0] atomic_op(input [ATOMIC_WIDTH-1:0] a,
         input [ATOMIC_WIDTH-1:0] b, input [2:0] size, input [7:0] atype);
 
@@ -175,6 +177,8 @@ module umiram #(
         end
     endfunction
 
+    /* verilator lint_on BLKSEQ */
+
     reg [ATOMIC_WIDTH-1:0] a_atomic;
     reg [ATOMIC_WIDTH-1:0] b_atomic;
     reg [ATOMIC_WIDTH-1:0] y_atomic;
@@ -194,16 +198,22 @@ module umiram #(
                     udev_resp_data[i*8 +: 8] <= mem[(i+udev_req_dstaddr[31:0])*8 +: 8];
                     if (req_cmd_atomic) begin
                         // blocking assignment
+                        /* verilator lint_off BLKSEQ */
                         a_atomic[i*8 +: 8] = mem[(i+udev_req_dstaddr[31:0])*8 +: 8];
+                        /* verilator lint_on BLKSEQ */
                     end
                 end
                 if (req_cmd_atomic) begin
                     for (i=0; i<nbytes; i=i+1) begin
                         // blocking assignment
+                        /* verilator lint_off BLKSEQ */
                         b_atomic[i*8 +: 8] = udev_req_data[i*8 +: 8];
+                        /* verilator lint_on BLKSEQ */
                     end
                     // blocking assignment
+                    /* verilator lint_off BLKSEQ */
                     y_atomic = atomic_op(a_atomic, b_atomic, req_size, req_atype);
+                    /* verilator lint_on BLKSEQ */
                     for (i=0; i<nbytes; i=i+1) begin
                         mem[(i+udev_req_dstaddr[31:0])*8 +: 8] <= y_atomic[i*8 +: 8];
                     end

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@
 from setuptools import setup, find_packages
 from pybind11.setup_helpers import Pybind11Extension, build_ext
 
-__version__ = "0.0.36"
+__version__ = "0.0.37"
 
 #################################################################################
 # parse_reqs, long_desc from https://github.com/siliconcompiler/siliconcompiler #

--- a/switchboard/verilog/sim/queue_to_sb_sim.sv
+++ b/switchboard/verilog/sim/queue_to_sb_sim.sv
@@ -93,7 +93,9 @@ module queue_to_sb_sim #(
                     `SB_EXT_FUNC(pi_sb_recv)(id, rdata, rdest, rlast, success);
                     /* verilator lint_on IGNOREDRETURN */
                 end else begin
+                    /* verilator lint_off BLKSEQ */
                     success = 32'd0;
+                    /* verilator lint_on BLKSEQ */
                 end
 
                 // if a packet was received, mark the output as valid
@@ -122,7 +124,9 @@ module queue_to_sb_sim #(
                     `SB_EXT_FUNC(pi_sb_recv)(id, rdata, rdest, rlast, success);
                     /* verilator lint_on IGNOREDRETURN */
                 end else begin
+                    /* verilator lint_off BLKSEQ */
                     success = 32'd0;
+                    /* verilator lint_on BLKSEQ */
                 end
 
                 // if a packet was received, mark the output as valid

--- a/switchboard/verilog/sim/sb_to_queue_sim.sv
+++ b/switchboard/verilog/sim/sb_to_queue_sim.sv
@@ -88,7 +88,9 @@ module sb_to_queue_sim #(
                 `SB_EXT_FUNC(pi_sb_send)(id, data_padded, dest, last, success);
                 /* verilator lint_on IGNOREDRETURN */
             end else begin
+                /* verilator lint_off BLKSEQ */
                 success = 32'd0;
+                /* verilator lint_on BLKSEQ */
             end
 
             // if the send was not successful, mark it pending. ready cannot be asserted
@@ -123,7 +125,9 @@ module sb_to_queue_sim #(
                 `SB_EXT_FUNC(pi_sb_send)(id, sdata, sdest, slast, success);
                 /* verilator lint_on IGNOREDRETURN */
             end else begin
+                /* verilator lint_off BLKSEQ */
                 success = 32'd0;
+                /* verilator lint_on BLKSEQ */
             end
 
             // if the re-send was unsuccessful, we have to keep ready de-asserted,


### PR DESCRIPTION
If this change breaks an existing test, the workaround is to set `warnings=[]` when instantiating `SbDut`.  However, it is recommended to fix or explicitly disable lint for `BLKSEQ` warnings, because they can result in bugs that are hard to track down.

The code in this PR is set up to make it easy to add more non-default warnings in the future.  I also needed to explicitly disable `BLKSEQ` in a few places in internal switchboard Verilog to resolve warnings that emerged.