### PR TITLE
Full AXI driver

### DIFF
--- a/examples/axi/Makefile
+++ b/examples/axi/Makefile
@@ -1,0 +1,17 @@
+# Copyright (c) 2024 Zero ASIC Corporation
+# This code is licensed under Apache License 2.0 (see LICENSE for details)
+
+.PHONY: verilator
+verilator:
+	./test.py --tool verilator
+
+.PHONY: icarus
+icarus:
+	./test.py --tool icarus
+
+.PHONY: clean
+clean:
+	rm -f queue-* *.q
+	rm -f *.vcd *.fst *.fst.hier
+	rm -rf obj_dir build
+	rm -f *.o *.vpi

--- a/examples/axi/README.md
+++ b/examples/axi/README.md
@@ -1,0 +1,64 @@
+# axi example
+
+This example shows how to interact with AXI subordinates using switchboard.  A Python script writes random data to an AXI memory implementation ([this one](https://github.com/alexforencich/verilog-axi/blob/master/rtl/axi_ram.v)).  Data is then read back from the memory in a random order and compared against a local model.
+
+To run the example, type `make`.  You'll see a Verilator build, followed by output like this:
+
+```text
+Wrote addr=0xa9 data=[204 151 236 115 123 156 212  84 147]
+Wrote addr=0xdc data=[181 183  45 240]
+Wrote addr=0xc6 data=[ 84 235  19  16 103]
+Wrote addr=0xa6 data=[177 195  66  57 208]
+Read addr=0x1f data=[140 199  71]
+Wrote addr=0x61 data=[233 182 131 230 213 188  23 178  44  99]
+PASS!
+```
+
+`make icarus` runs the example using Icarus Verilog as the digital simulator.
+
+In the Verilog implementation, [testbench.sv](testbench.sv) instantiates a switchboard module that acts as an AXI manager.
+
+```verilog
+`include "switchboard.vh"
+
+...
+
+`SB_AXI_M(sb_axi_m_i, axi, DATA_WIDTH, ADDR_WIDTH, ID_WIDTH);
+```
+
+Based on the macro arguments, the module instance is called `sb_axi_m_i` and it connects to AXI signals starting with the prefix `axi`.  The module is configured to connect to switchboard queues in an `initial` block:
+
+```verilog
+initial begin
+    sb_axi_m_i.init("axi");
+end
+```
+
+The argument, `axi`, is the prefix used when connecting to the queues that convey AXI traffic.  Since AXI has 5 channels, 5 queues will be connected as a result of this function call: `axi-aw.q`, `axi-w.q`, `axi-b.q`, `axi-ar.q`, `axi-r.q`.  If the argument of `init` were instead `myqueue`, then the queue names would all start with `myqueue` instead of `axi`.
+
+In the Python script [test.py](test.py), a corresponding `AxiTxRx` object is created, using the same shorthand for connecting to all 5 queues.
+
+```python
+axi = AxiTxRx('axi', data_width=..., addr_width=..., id_width=...)
+```
+
+As with `UmiTxRx`, this object may be used to issue read and write transactions involving numpy scalars and arrays.  Under the hood, each transaction may be converted to multiple cycles of AXI transactions, with the write strobe automatically calculated in each cycle.
+
+```python
+axi.write(0x12, np.uint8(0x34))
+value = axi.read(0x12, np.uint8)  # value will contain 0x34
+```
+
+The `dtype` can be something other than a byte (even if the data type is wider than `data_width`)
+
+```python
+axi.write(0x12, np.uint64(0xdeadbeefcafed00d))
+value = axi.read(0x12, np.uint64)  # value will contain deadbeefcafed00d
+```
+
+It is also possible to read/write numpy arrays
+
+```python
+axi.write(0x12, np.array([0x1234, 0x5678], dtype=np.uint16))
+value = axi.read(0x12, 2, np.uint16)  # value will contain [0x1234, 0x5678]
+```

--- a/examples/axi/test.py
+++ b/examples/axi/test.py
@@ -14,12 +14,12 @@ from argparse import ArgumentParser
 from switchboard import SbDut, AxiTxRx
 
 
-def main(n=100, fast=False, tool='verilator', max_bytes=10):
+def main(n=100, fast=False, tool='verilator', max_bytes=10, max_beats=256):
     # build the simulator
     dut = build_testbench(fast=fast, tool=tool)
 
     # create the queues
-    axi = AxiTxRx('axi', data_width=32, addr_width=8, id_width=8)
+    axi = AxiTxRx('axi', data_width=32, addr_width=8, id_width=8, max_beats=max_beats)
 
     # launch the simulation
     dut.simulate()
@@ -100,6 +100,8 @@ if __name__ == '__main__':
         ' words to write as part of the test.')
     parser.add_argument('--max-bytes', type=int, default=10, help='Maximum'
         ' number of bytes in any single read/write.')
+    parser.add_argument('--max-beats', type=int, default=256, help='Maximum'
+        ' number of beats to use in AXI transfers.')
     parser.add_argument('--fast', action='store_true', help='Do not build'
         ' the simulator binary if it has already been built.')
     parser.add_argument('--tool', default='verilator', choices=['icarus', 'verilator'],

--- a/examples/axi/test.py
+++ b/examples/axi/test.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+
+# Example illustrating how to interact with the umi_fifo module
+
+# Copyright (c) 2024 Zero ASIC Corporation
+# This code is licensed under Apache License 2.0 (see LICENSE for details)
+
+import sys
+import random
+import numpy as np
+
+from math import ceil, log2
+from argparse import ArgumentParser
+from switchboard import SbDut, AxiTxRx
+
+
+def main(n=100, fast=False, tool='verilator', max_bytes=10):
+    # build the simulator
+    dut = build_testbench(fast=fast, tool=tool)
+
+    # create the queues
+    axi = AxiTxRx('axi', data_width=32, addr_width=8, id_width=8)
+
+    # launch the simulation
+    dut.simulate()
+
+    # run the test: write to random addresses and read back in a random order
+
+    addr_bytes = axi.addr_width // 8
+
+    valid_addr_width = axi.addr_width - ceil(log2(addr_bytes))
+    model = np.zeros((1 << valid_addr_width,), dtype=np.uint8)
+
+    success = True
+
+    for _ in range(n):
+        addr = random.randint(0, (1 << valid_addr_width) - 1)
+        size = random.randint(1, min(max_bytes, (1 << valid_addr_width) - addr))
+
+        if random.random() < 0.5:
+            #########
+            # write #
+            #########
+
+            data = np.random.randint(0, 255, size=size, dtype=np.uint8)
+
+            # perform the write
+            axi.write(addr, data)
+            print(f'Wrote addr=0x{addr:0{addr_bytes * 2}x} data={data}')
+
+            # update local memory model
+            model[addr:addr + size] = data
+        else:
+            ########
+            # read #
+            ########
+
+            # perform the read
+            data = axi.read(addr, size)
+            print(f'Read addr=0x{addr:0{addr_bytes * 2}x} data={data}')
+
+            # check against the model
+            if not np.array_equal(data, model[addr:addr + size]):
+                print('MISMATCH')
+                success = False
+
+    if success:
+        print("PASS!")
+        sys.exit(0)
+    else:
+        print("FAIL")
+        sys.exit(1)
+
+
+def build_testbench(fast=False, tool='verilator'):
+    dut = SbDut(tool=tool, default_main=True)
+
+    dut.register_package_source(
+        'verilog-axi',
+        'git+https://github.com/alexforencich/verilog-axi.git',
+        '38915fb'
+    )
+
+    dut.input('rtl/axi_ram.v', package='verilog-axi')
+    dut.input('testbench.sv')
+
+    dut.add('tool', 'verilator', 'task', 'compile', 'warningoff', 'WIDTHEXPAND')
+    dut.add('tool', 'verilator', 'task', 'compile', 'warningoff', 'CASEINCOMPLETE')
+    dut.add('tool', 'verilator', 'task', 'compile', 'warningoff', 'WIDTHTRUNC')
+    dut.add('tool', 'verilator', 'task', 'compile', 'warningoff', 'TIMESCALEMOD')
+
+    dut.build(fast=fast)
+
+    return dut
+
+
+if __name__ == '__main__':
+    parser = ArgumentParser()
+    parser.add_argument('-n', type=int, default=100, help='Number of'
+        ' words to write as part of the test.')
+    parser.add_argument('--max-bytes', type=int, default=10, help='Maximum'
+        ' number of bytes in any single read/write.')
+    parser.add_argument('--fast', action='store_true', help='Do not build'
+        ' the simulator binary if it has already been built.')
+    parser.add_argument('--tool', default='verilator', choices=['icarus', 'verilator'],
+        help='Name of the simulator to use.')
+    args = parser.parse_args()
+
+    main(n=args.n, fast=args.fast, tool=args.tool, max_bytes=args.max_bytes)

--- a/examples/axi/testbench.sv
+++ b/examples/axi/testbench.sv
@@ -1,0 +1,88 @@
+// Copyright (c) 2024 Zero ASIC Corporation
+// This code is licensed under Apache License 2.0 (see LICENSE for details)
+
+`default_nettype none
+
+`include "switchboard.vh"
+
+module testbench (
+    `ifdef VERILATOR
+        input clk
+    `endif
+);
+    `ifndef VERILATOR
+
+        reg clk;
+        always begin
+            clk = 1'b0;
+            #5;
+            clk = 1'b1;
+            #5;
+        end
+
+    `endif
+
+    // Declare AXI wires
+
+    localparam DATA_WIDTH = 32;
+    localparam ADDR_WIDTH = 8;
+    localparam ID_WIDTH = 8;
+
+    `SB_AXI_WIRES(axi, DATA_WIDTH, ADDR_WIDTH, ID_WIDTH);
+
+    // Instantiate DUT
+
+    wire rst;
+
+    axi_ram #(
+        .DATA_WIDTH(DATA_WIDTH),
+        .ADDR_WIDTH(ADDR_WIDTH),
+        .ID_WIDTH(ID_WIDTH)
+    ) axi_ram_i (
+        .clk(clk),
+        .rst(rst),
+        `SB_AXI_CONNECT(s_axi, axi)
+    );
+
+    // Instantiate switchboard module
+
+    `SB_AXI_M(sb_axi_m_i, axi, DATA_WIDTH, ADDR_WIDTH, ID_WIDTH);
+
+    initial begin
+        /* verilator lint_off IGNOREDRETURN */
+        sb_axi_m_i.init("axi");
+        /* verilator lint_on IGNOREDRETURN */
+    end
+
+    // Initialize RAM to zeros for easy comparison against a behavioral model
+
+    localparam VALID_ADDR_WIDTH = ADDR_WIDTH - $clog2(DATA_WIDTH/8);
+
+    initial begin
+        for (int i=0; i<2**VALID_ADDR_WIDTH; i=i+1) begin
+            axi_ram_i.mem[i] = 0;
+        end
+    end
+
+    // Generate reset signal
+
+    reg [7:0] rst_vec = 8'hFF;
+
+    always @(posedge clk) begin
+        rst_vec <= {rst_vec[6:0], 1'b0};
+    end
+
+    assign rst = rst_vec[7];
+
+    // Set up waveform probing
+
+    initial begin
+        if ($test$plusargs("trace")) begin
+            $dumpfile("testbench.vcd");
+            $dumpvars(0, testbench);
+        end
+    end
+
+endmodule
+
+`default_nettype wire

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@
 from setuptools import setup, find_packages
 from pybind11.setup_helpers import Pybind11Extension, build_ext
 
-__version__ = "0.0.39"
+__version__ = "0.0.40"
 
 #################################################################################
 # parse_reqs, long_desc from https://github.com/siliconcompiler/siliconcompiler #

--- a/switchboard/__init__.py
+++ b/switchboard/__init__.py
@@ -19,3 +19,4 @@ from .bitvector import BitVector
 from .uart_xactor import uart_xactor
 from .sbtcp import start_tcp_bridge
 from .axil import AxiLiteTxRx
+from .axi import AxiTxRx

--- a/switchboard/axi.py
+++ b/switchboard/axi.py
@@ -1,0 +1,349 @@
+# Python interface for AXI reads and writes
+
+# Copyright (c) 2024 Zero ASIC Corporation
+# This code is licensed under Apache License 2.0 (see LICENSE for details)
+
+import numpy as np
+
+from math import floor, ceil, log2
+from numbers import Integral
+
+from _switchboard import PySbPacket, PySbTx, PySbRx
+
+
+class AxiTxRx:
+    def __init__(
+        self,
+        uri: str,
+        fresh: bool = True,
+        data_width: int = 32,
+        addr_width: int = 16,
+        id_width: int = 8,
+        prot: int = 0,
+        resp_expected: str = 'OKAY',
+        queue_suffix: str = '.q'
+    ):
+        """
+        Parameters
+        ----------
+        uri: str
+            Base name of for switchboard queues used to convey AXI transactions.  Five
+            queues are used: write address (aw), write data (w), write response (b),
+            read address (ar), and read response (r).  If the base name provided is
+            "axi", the correponding queues will be "axi-aw.q", "axi-w.q", "axi-b.q",
+            "axi-ar.q" and "axi-r.q".  The suffix used can be changed via the
+            "queue_suffix" argument if needed.
+        fresh: bool, optional
+           If True (default), the queue specified by the uri parameter will get cleared
+           before executing the simulation.
+        data_width: int, optional
+            Width the write and read data buses, in bits.
+        addr_width: int, optional
+            Width the write and read address buses, in bits.
+        prot: int, optional
+            Default value of PROT to use for read and write transactions.  Can be
+            overridden on a transaction-by-transaction basis.
+        resp_expected: str, optional
+            Default response to expect from reads and writes.  Options are 'OKAY',
+            'EXOKAY', 'SLVERR', 'DECERR'.  None means "don't check the response".
+            This default can be overridden on a transaction-by-transaction basis.
+        queue_suffix: str, optional
+            File extension/suffix to use when naming switchboard queues that carry
+            AXI transactions.  For example, if set to ".queue", the write address
+            queue name will be "{uri}-aw.queue"
+        """
+
+        # check data types
+        assert isinstance(data_width, Integral), 'data_width must be an integer'
+        assert isinstance(addr_width, Integral), 'addr_width must be an integer'
+
+        # check that data width is a multiple of a byte
+        data_width_choices = [8, 16, 32, 64, 128, 256, 512, 1024]
+        assert data_width in data_width_choices, \
+            f'data_width must be in {data_width_choices}'
+
+        # check that data and address widths are supported
+        SBDW = 416
+        assert 0 < data_width <= floor(SBDW / (1 + (1 / 8))), 'data_width out of range'
+        assert 0 < addr_width <= SBDW - 3, 'addr_width out of range'
+
+        # save settings
+        self.data_width = data_width
+        self.addr_width = addr_width
+        self.id_width = id_width
+        self.default_prot = prot
+        self.default_resp_expected = resp_expected
+
+        # create the queues
+        self.aw = PySbTx(f'{uri}-aw{queue_suffix}', fresh=fresh)
+        self.w = PySbTx(f'{uri}-w{queue_suffix}', fresh=fresh)
+        self.b = PySbRx(f'{uri}-b{queue_suffix}', fresh=fresh)
+        self.ar = PySbTx(f'{uri}-ar{queue_suffix}', fresh=fresh)
+        self.r = PySbRx(f'{uri}-r{queue_suffix}', fresh=fresh)
+
+    @property
+    def strb_width(self):
+        return self.data_width // 8
+
+    def write(
+        self,
+        addr: Integral,
+        data,
+        prot: Integral = None,
+        resp_expected: str = None
+    ):
+        """
+        Parameters
+        ----------
+        addr: int
+            Address to write to
+
+        data: np.uint8, np.uint16, np.uint32, np.uint64, or np.array
+            Data to write
+
+        prot: Integral
+            Value of PROT for this transaction.  Defaults to the value provided in the
+            AxiTxRx constructor if not provided, which in turn defaults to 0.
+
+        resp_expected: str, optional
+            Response to expect for this transaction.  Options are 'OKAY', 'EXOKAY', 'SLVERR',
+            'DECERR', and None.  None means, "don't check the response". Defaults to the
+            value provided in the AxiTxRx constructor if not provided, which in turn defaults
+            to 'OKAY'
+
+        Returns
+        -------
+        str
+            String representation of the response code, which may be 'OKAY', 'EXOKAY',
+            'SLVERR', or 'DECERR'.
+        """
+
+        # set defaults
+
+        if prot is None:
+            prot = self.default_prot
+
+        if resp_expected is None:
+            resp_expected = self.default_resp_expected
+
+        # check/standardize data types
+
+        assert isinstance(addr, Integral), 'addr must be an integer'
+        addr = int(addr)
+
+        assert isinstance(prot, Integral), 'prot must be an integer'
+        prot = int(prot)
+
+        if isinstance(data, np.ndarray):
+            if data.ndim == 0:
+                write_data = np.atleast_1d(data)
+            elif data.ndim == 1:
+                write_data = data
+            else:
+                raise ValueError(f'Can only write 1D arrays (got ndim={data.ndim})')
+
+            if not np.issubdtype(write_data.dtype, np.integer):
+                raise ValueError('Can only write integer dtypes such as uint8, uint16, etc.'
+                    f'  (got dtype "{data.dtype}")')
+        elif isinstance(data, np.integer):
+            write_data = np.array(data, ndmin=1, copy=False)
+        else:
+            raise TypeError(f"Unknown data type: {type(data)}")
+
+        write_data = write_data.view(np.uint8)
+        bytes_to_send = write_data.size
+
+        # range validation
+
+        assert 0 <= addr < (1 << self.addr_width), 'addr out of range'
+        assert addr + bytes_to_send <= (1 << self.addr_width), \
+            "transaction exceeds the address space."
+
+        assert 0 <= prot < (1 << 3), 'prot out of range'
+
+        # loop until all data is sent
+        # TODO: move to C++?
+
+        bytes_sent = 0
+
+        data_bytes = self.data_width // 8
+        strb_bytes = (self.strb_width + 7) // 8
+
+        addr_mask = (1 << self.addr_width) - 1
+        addr_mask >>= ceil(log2(data_bytes))
+        addr_mask <<= ceil(log2(data_bytes))
+
+        while bytes_sent < bytes_to_send:
+            # find the offset into the data bus for this cycle.  bytes below
+            # the offset will have write strobe de-asserted.
+            offset = addr % data_bytes
+
+            # determine how many bytes we're sending in this cycle
+            bytes_this_cycle = min(bytes_to_send - bytes_sent, data_bytes - offset)
+
+            # extract those bytes from the whole input data array, picking
+            # up where we left off from the last iteration
+            data_this_cycle = write_data[bytes_sent:bytes_sent + bytes_this_cycle]
+
+            # calculate strobe value based on the offset and number
+            # of bytes that we're writing.
+            strb = ((1 << bytes_this_cycle) - 1) << offset
+            strb = strb.to_bytes(strb_bytes, 'little')
+            strb = np.frombuffer(strb, dtype=np.uint8)
+
+            # transmit the write address
+            pack = (prot << self.addr_width) | (addr & addr_mask)
+            pack = pack.to_bytes((self.addr_width + 3 + 7) // 8, 'little')
+            pack = np.frombuffer(pack, dtype=np.uint8)
+            pack = PySbPacket(data=pack, flags=1, destination=0)
+            self.aw.send(pack)
+
+            # write data and strobe
+            pack = np.empty((data_bytes + strb_bytes,), dtype=np.uint8)
+            pack[offset:offset + bytes_this_cycle] = data_this_cycle
+            pack[data_bytes:data_bytes + strb_bytes] = strb
+            pack = PySbPacket(data=pack, flags=1, destination=0)
+            self.w.send(pack)
+
+            # wait for response
+            pack = self.b.recv()
+            pack = pack.data.tobytes()
+            pack = int.from_bytes(pack, 'little')
+
+            # decode the response
+            resp = decode_resp(pack & 0b11)
+
+            # check the response if desired
+            if resp_expected is not None:
+                assert resp.upper() == resp_expected.upper(), f'Unexpected response: {resp}'
+
+            # increment pointers
+            bytes_sent += bytes_this_cycle
+            addr += bytes_this_cycle
+
+        # return the last reponse
+        return resp
+
+    def read(
+        self,
+        addr: Integral,
+        num_or_dtype,
+        dtype=np.uint8,
+        prot: Integral = None,
+        resp_expected: str = None
+    ):
+        """
+        Parameters
+        ----------
+        addr: int
+            Address to read from
+
+        num_or_dtype: int or numpy integer datatype
+            If a plain int, `num_or_datatype` specifies the number of bytes to be read.
+            If a numpy integer datatype (np.uint8, np.uint16, etc.), num_or_datatype
+            specifies the data type to be returned.
+
+        dtype: numpy integer datatype, optional
+            If num_or_dtype is a plain integer, the value returned by this function
+            will be a numpy array of type "dtype".  On the other hand, if num_or_dtype
+            is a numpy datatype, the value returned will be a scalar of that datatype.
+
+        prot: Integral
+            Value of PROT for this transaction.  Defaults to the value provided in the
+            AxiTxRx constructor if not provided, which in turn defaults to 0.
+
+        resp_expected: str, optional
+            Response to expect for this transaction.  Options are 'OKAY', 'EXOKAY', 'SLVERR',
+            'DECERR', and None.  None means, "don't check the response". Defaults to the
+            value provided in the AxiTxRx constructor if not provided, which in turn defaults
+            to 'OKAY'
+
+        Returns
+        -------
+        int
+            Value read, as an arbitrary-size Python integer.
+        """
+
+        # set defaults
+
+        if prot is None:
+            prot = self.default_prot
+
+        if resp_expected is None:
+            resp_expected = self.default_resp_expected
+
+        # check/standardize data types
+
+        assert isinstance(addr, Integral), 'addr must be an integer'
+        addr = int(addr)
+
+        assert isinstance(prot, Integral), 'prot must be an integer'
+        prot = int(prot)
+
+        if isinstance(num_or_dtype, (type, np.dtype)):
+            bytes_to_read = np.dtype(num_or_dtype).itemsize
+        else:
+            bytes_to_read = num_or_dtype * np.dtype(dtype).itemsize
+
+        # range validation
+
+        assert 0 <= addr < (1 << self.addr_width), 'addr out of range'
+        assert addr + bytes_to_read <= (1 << self.addr_width), \
+            "transaction exceeds the address space."
+
+        assert 0 <= prot < (1 << 3), 'prot out of range'
+
+        # loop until all data is read
+        # TODO: move to C++?
+
+        bytes_read = 0
+        data_bytes = self.data_width // 8
+
+        addr_mask = (1 << self.addr_width) - 1
+        addr_mask >>= ceil(log2(data_bytes))
+        addr_mask <<= ceil(log2(data_bytes))
+
+        retval = np.empty((bytes_to_read,), dtype=np.uint8)
+
+        while bytes_read < bytes_to_read:
+            # find the offset into the data bus for this cycle
+            offset = addr % data_bytes
+
+            # determine what data we're reading this cycle
+            bytes_this_cycle = min(bytes_to_read - bytes_read, data_bytes - offset)
+
+            # transmit read address
+            pack = (prot << self.addr_width) | (addr & addr_mask)
+            pack = pack.to_bytes((self.addr_width + 3 + 7) // 8, 'little')
+            pack = np.frombuffer(pack, dtype=np.uint8)
+            pack = PySbPacket(data=pack, flags=1, destination=0)
+            self.ar.send(pack)
+
+            # wait for response
+            pack = self.r.recv()
+            data = pack.data[offset:offset + bytes_this_cycle]
+            resp = pack.data[data_bytes] & 0b11
+
+            # check the reponse
+            if resp_expected is not None:
+                resp = decode_resp(resp)
+                assert resp.upper() == resp_expected.upper(), f'Unexpected response: {resp}'
+
+            # add this data to the return value
+            retval[bytes_read:bytes_read + bytes_this_cycle] = data
+
+            # increment pointers
+            bytes_read += bytes_this_cycle
+            addr += bytes_this_cycle
+
+        if isinstance(num_or_dtype, (type, np.dtype)):
+            return retval.view(num_or_dtype)[0]
+        else:
+            return retval.view(dtype)
+
+
+def decode_resp(resp: Integral):
+    assert isinstance(resp, Integral), 'response code must be an integer'
+    assert 0 <= resp <= 3, 'response code out of range'
+
+    return ['OKAY', 'EXOKAY', 'SLVERR', 'DECERR'][resp]

--- a/switchboard/axi.py
+++ b/switchboard/axi.py
@@ -167,7 +167,7 @@ class AxiTxRx:
         bytes_sent = 0
 
         data_bytes = self.data_width // 8
-        strb_bytes = (self.strb_width + 7) // 8
+        strb_bytes = (self.strb_width + 1 + 7) // 8
 
         addr_mask = (1 << self.addr_width) - 1
         addr_mask >>= ceil(log2(data_bytes))
@@ -193,7 +193,10 @@ class AxiTxRx:
 
             # transmit the write address
             pack = (prot << self.addr_width) | (addr & addr_mask)
-            pack = pack.to_bytes((self.addr_width + 3 + 7) // 8, 'little')
+            pack = pack.to_bytes(
+                (self.addr_width + 3 + self.id_width + 8 + 3 + 2 + 1 + 4 + 7) // 8,
+                'little'
+            )
             pack = np.frombuffer(pack, dtype=np.uint8)
             pack = PySbPacket(data=pack, flags=1, destination=0)
             self.aw.send(pack)
@@ -314,7 +317,10 @@ class AxiTxRx:
 
             # transmit read address
             pack = (prot << self.addr_width) | (addr & addr_mask)
-            pack = pack.to_bytes((self.addr_width + 3 + 7) // 8, 'little')
+            pack = pack.to_bytes(
+                (self.addr_width + 3 + self.id_width + 8 + 3 + 2 + 1 + 4 + 7) // 8,
+                'little'
+            )
             pack = np.frombuffer(pack, dtype=np.uint8)
             pack = PySbPacket(data=pack, flags=1, destination=0)
             self.ar.send(pack)

--- a/switchboard/verilog/common/switchboard.vh
+++ b/switchboard/verilog/common/switchboard.vh
@@ -6,12 +6,12 @@
 `ifndef SWITCHBOARD_VH_
 `define SWITCHBOARD_VH_
 
-`define UMI_PORT_WIRES_WIDTHS(prefix, dw, cw, aw)       \
-        wire prefix``_valid;                            \
-        wire [cw - 1 : 0] prefix``_cmd;                 \
-        wire [aw - 1 : 0] prefix``_dstaddr;             \
-        wire [aw - 1 : 0] prefix``_srcaddr;             \
-        wire [dw - 1 : 0] prefix``_data;                \
+`define UMI_PORT_WIRES_WIDTHS(prefix, dw, cw, aw)               \
+        wire prefix``_valid;                                    \
+        wire [cw - 1 : 0] prefix``_cmd;                         \
+        wire [aw - 1 : 0] prefix``_dstaddr;                     \
+        wire [aw - 1 : 0] prefix``_srcaddr;                     \
+        wire [dw - 1 : 0] prefix``_data;                        \
         wire prefix``_ready
 
 `define SWITCHBOARD_SIM_PORT(prefix, dw)                        \
@@ -111,6 +111,124 @@
         .m_axil_rresp(signal``_rresp),                          \
         .m_axil_rvalid(signal``_rvalid),                        \
         .m_axil_rready(signal``_rready)                         \
+    )
+
+`define SB_AXI_WIRES(signal, dw, aw, idw)                       \
+    wire [(idw)-1:0]       signal``_awid;                       \
+    wire [(aw)-1:0]        signal``_awaddr;                     \
+    wire [7:0]             signal``_awlen;                      \
+    wire [2:0]             signal``_awsize;                     \
+    wire [1:0]             signal``_awburst;                    \
+    wire                   signal``_awlock;                     \
+    wire [3:0]             signal``_awcache;                    \
+    wire [2:0]             signal``_awprot;                     \
+    wire                   signal``_awvalid;                    \
+    wire                   signal``_awready;                    \
+    wire [(dw)-1:0]        signal``_wdata;                      \
+    wire [((dw)/8)-1:0]    signal``_wstrb;                      \
+    wire                   signal``_wlast;                      \
+    wire                   signal``_wvalid;                     \
+    wire                   signal``_wready;                     \
+    wire [(idw)-1:0]       signal``_bid;                        \
+    wire [1:0]             signal``_bresp;                      \
+    wire                   signal``_bvalid;                     \
+    wire                   signal``_bready;                     \
+    wire [(idw)-1:0]       signal``_arid;                       \
+    wire [(aw)-1:0]        signal``_araddr;                     \
+    wire [7:0]             signal``_arlen;                      \
+    wire [2:0]             signal``_arsize;                     \
+    wire [1:0]             signal``_arburst;                    \
+    wire                   signal``_arlock;                     \
+    wire [3:0]             signal``_arcache;                    \
+    wire [2:0]             signal``_arprot;                     \
+    wire                   signal``_arvalid;                    \
+    wire                   signal``_arready;                    \
+    wire [(idw)-1:0]       signal``_rid;                        \
+    wire [(dw)-1:0]        signal``_rdata;                      \
+    wire [1:0]             signal``_rresp;                      \
+    wire                   signal``_rlast;                      \
+    wire                   signal``_rvalid;                     \
+    wire                   signal``_rready;
+
+`define SB_AXI_CONNECT(a, b)                                    \
+    .a``_awid(b``_awid),                                        \
+    .a``_awaddr(b``_awaddr),                                    \
+    .a``_awlen(b``_awlen),                                      \
+    .a``_awsize(b``_awsize),                                    \
+    .a``_awburst(b``_awburst),                                  \
+    .a``_awlock(b``_awlock),                                    \
+    .a``_awcache(b``_awcache),                                  \
+    .a``_awprot(b``_awprot),                                    \
+    .a``_awvalid(b``_awvalid),                                  \
+    .a``_awready(b``_awready),                                  \
+    .a``_wdata(b``_wdata),                                      \
+    .a``_wstrb(b``_wstrb),                                      \
+    .a``_wlast(b``_wlast),                                      \
+    .a``_wvalid(b``_wvalid),                                    \
+    .a``_wready(b``_wready),                                    \
+    .a``_bid(b``_bid),                                          \
+    .a``_bresp(b``_bresp),                                      \
+    .a``_bvalid(b``_bvalid),                                    \
+    .a``_bready(b``_bready),                                    \
+    .a``_arid(b``_arid),                                        \
+    .a``_araddr(b``_araddr),                                    \
+    .a``_arlen(b``_arlen),                                      \
+    .a``_arsize(b``_arsize),                                    \
+    .a``_arburst(b``_arburst),                                  \
+    .a``_arlock(b``_arlock),                                    \
+    .a``_arcache(b``_arcache),                                  \
+    .a``_arprot(b``_arprot),                                    \
+    .a``_arvalid(b``_arvalid),                                  \
+    .a``_arready(b``_arready),                                  \
+    .a``_rid(b``_rid),                                          \
+    .a``_rdata(b``_rdata),                                      \
+    .a``_rresp(b``_rresp),                                      \
+    .a``_rlast(b``_rlast),                                      \
+    .a``_rvalid(b``_rvalid),                                    \
+    .a``_rready(b``_rready)
+
+`define SB_AXI_M(mod, signal, dw, aw, idw)                      \
+    sb_axi_m #(                                                \
+        .DATA_WIDTH(dw),                                        \
+        .ADDR_WIDTH(aw),                                        \
+        .ID_WIDTH(idw)                                          \
+    ) mod (                                                     \
+        .clk(clk),                                              \
+        .m_axi_awid(signal``_awid),                             \
+        .m_axi_awaddr(signal``_awaddr),                         \
+        .m_axi_awlen(signal``_awlen),                           \
+        .m_axi_awsize(signal``_awsize),                         \
+        .m_axi_awburst(signal``_awburst),                       \
+        .m_axi_awlock(signal``_awlock),                         \
+        .m_axi_awcache(signal``_awcache),                       \
+        .m_axi_awprot(signal``_awprot),                         \
+        .m_axi_awvalid(signal``_awvalid),                       \
+        .m_axi_awready(signal``_awready),                       \
+        .m_axi_wdata(signal``_wdata),                           \
+        .m_axi_wstrb(signal``_wstrb),                           \
+        .m_axi_wlast(signal``_wlast),                           \
+        .m_axi_wvalid(signal``_wvalid),                         \
+        .m_axi_wready(signal``_wready),                         \
+        .m_axi_bid(signal``_bid),                               \
+        .m_axi_bresp(signal``_bresp),                           \
+        .m_axi_bvalid(signal``_bvalid),                         \
+        .m_axi_bready(signal``_bready),                         \
+        .m_axi_arid(signal``_arid),                             \
+        .m_axi_araddr(signal``_araddr),                         \
+        .m_axi_arlen(signal``_arlen),                           \
+        .m_axi_arsize(signal``_arsize),                         \
+        .m_axi_arburst(signal``_arburst),                       \
+        .m_axi_arlock(signal``_arlock),                         \
+        .m_axi_arcache(signal``_arcache),                       \
+        .m_axi_arprot(signal``_arprot),                         \
+        .m_axi_arvalid(signal``_arvalid),                       \
+        .m_axi_arready(signal``_arready),                       \
+        .m_axi_rid(signal``_rid),                               \
+        .m_axi_rdata(signal``_rdata),                           \
+        .m_axi_rresp(signal``_rresp),                           \
+        .m_axi_rlast(signal``_rlast),                           \
+        .m_axi_rvalid(signal``_rvalid),                         \
+        .m_axi_rready(signal``_rready)                          \
     )
 
 `endif

--- a/switchboard/verilog/sim/sb_axi_m.sv
+++ b/switchboard/verilog/sim/sb_axi_m.sv
@@ -1,0 +1,196 @@
+// Copyright (c) 2024 Zero ASIC Corporation
+// This code is licensed under Apache License 2.0 (see LICENSE for details)
+
+`default_nettype none
+
+module sb_axi_m #(
+    // AXI settings
+    parameter DATA_WIDTH = 32,
+    parameter ADDR_WIDTH = 16,
+    parameter STRB_WIDTH = (DATA_WIDTH/8),
+    parameter ID_WIDTH = 8,
+
+    // Switchboard settings
+    parameter integer VALID_MODE_DEFAULT=0,
+    parameter integer READY_MODE_DEFAULT=0
+) (
+    input wire clk,
+
+    // AXI master interface
+    // adapted from https://github.com/alexforencich/verilog-axi
+    output wire [ID_WIDTH-1:0]    m_axi_awid,
+    output wire [ADDR_WIDTH-1:0]  m_axi_awaddr,
+    output wire [7:0]             m_axi_awlen,
+    output wire [2:0]             m_axi_awsize,
+    output wire [1:0]             m_axi_awburst,
+    output wire                   m_axi_awlock,
+    output wire [3:0]             m_axi_awcache,
+    output wire [2:0]             m_axi_awprot,
+    output wire                   m_axi_awvalid,
+    input  wire                   m_axi_awready,
+    output wire [DATA_WIDTH-1:0]  m_axi_wdata,
+    output wire [STRB_WIDTH-1:0]  m_axi_wstrb,
+    output wire                   m_axi_wlast,
+    output wire                   m_axi_wvalid,
+    input  wire                   m_axi_wready,
+    input  wire [ID_WIDTH-1:0]    m_axi_bid,
+    input  wire [1:0]             m_axi_bresp,
+    input  wire                   m_axi_bvalid,
+    output wire                   m_axi_bready,
+    output wire [ID_WIDTH-1:0]    m_axi_arid,
+    output wire [ADDR_WIDTH-1:0]  m_axi_araddr,
+    output wire [7:0]             m_axi_arlen,
+    output wire [2:0]             m_axi_arsize,
+    output wire [1:0]             m_axi_arburst,
+    output wire                   m_axi_arlock,
+    output wire [3:0]             m_axi_arcache,
+    output wire [2:0]             m_axi_arprot,
+    output wire                   m_axi_arvalid,
+    input  wire                   m_axi_arready,
+    input  wire [ID_WIDTH-1:0]    m_axi_rid,
+    input  wire [DATA_WIDTH-1:0]  m_axi_rdata,
+    input  wire [1:0]             m_axi_rresp,
+    input  wire                   m_axi_rlast,
+    input  wire                   m_axi_rvalid,
+    output wire                   m_axi_rready
+);
+    // AW channel
+
+    queue_to_sb_sim #(
+        .VALID_MODE_DEFAULT(VALID_MODE_DEFAULT),
+        .DW(ADDR_WIDTH + 3)
+    ) aw_channel (
+        .clk(clk),
+        .data({m_axi_awprot, m_axi_awaddr}),
+        .dest(),
+        .last(),
+        .valid(m_axi_awvalid),
+        .ready(m_axi_awready)
+    );
+
+    assign m_axi_awid = 0;
+    assign m_axi_awlen = 0;
+    assign m_axi_awsize = 0;
+    assign m_axi_awburst = 0;
+    assign m_axi_awlock = 0;
+    assign m_axi_awcache = 0;
+
+    // W channel
+
+    queue_to_sb_sim #(
+        .VALID_MODE_DEFAULT(VALID_MODE_DEFAULT),
+        .DW(DATA_WIDTH + STRB_WIDTH)
+    ) w_channel (
+        .clk(clk),
+        .data({m_axi_wstrb, m_axi_wdata}),
+        .dest(),
+        .last(),
+        .valid(m_axi_wvalid),
+        .ready(m_axi_wready)
+    );
+
+    assign m_axi_wlast = 0;
+
+    // B channel
+
+    sb_to_queue_sim #(
+        .READY_MODE_DEFAULT(READY_MODE_DEFAULT),
+        .DW(2)
+    ) b_channel (
+        .clk(clk),
+        .data(m_axi_bresp),
+        .dest(),
+        .last(),
+        .valid(m_axi_bvalid),
+        .ready(m_axi_bready)
+    );
+
+    // AR channel
+
+    queue_to_sb_sim #(
+        .VALID_MODE_DEFAULT(VALID_MODE_DEFAULT),
+        .DW(ADDR_WIDTH + 3)
+    ) ar_channel (
+        .clk(clk),
+        .data({m_axi_arprot, m_axi_araddr}),
+        .dest(),
+        .last(),
+        .valid(m_axi_arvalid),
+        .ready(m_axi_arready)
+    );
+
+    assign m_axi_arid = 0;
+    assign m_axi_arlen = 0;
+    assign m_axi_arsize = 0;
+    assign m_axi_arburst = 0;
+    assign m_axi_arlock = 0;
+    assign m_axi_arcache = 0;
+
+    // R channel
+
+    sb_to_queue_sim #(
+        .READY_MODE_DEFAULT(READY_MODE_DEFAULT),
+        .DW(DATA_WIDTH + 2)
+    ) r_channel (
+        .clk(clk),
+        .data({m_axi_rresp, m_axi_rdata}),
+        .dest(),
+        .last(),
+        .valid(m_axi_rvalid),
+        .ready(m_axi_rready)
+    );
+
+    // handle differences between simulators
+
+    `ifdef __ICARUS__
+        `define SB_START_FUNC task
+        `define SB_END_FUNC endtask
+    `else
+        `define SB_START_FUNC function void
+        `define SB_END_FUNC endfunction
+    `endif
+
+    `SB_START_FUNC init(input string uri);
+        string s;
+
+        /* verilator lint_off IGNOREDRETURN */
+        $sformat(s, "%0s-aw.q", uri);
+        aw_channel.init(s);
+
+        $sformat(s, "%0s-w.q", uri);
+        w_channel.init(s);
+
+        $sformat(s, "%0s-b.q", uri);
+        b_channel.init(s);
+
+        $sformat(s, "%0s-ar.q", uri);
+        ar_channel.init(s);
+
+        $sformat(s, "%0s-r.q", uri);
+        r_channel.init(s);
+        /* verilator lint_on IGNOREDRETURN */
+    `SB_END_FUNC
+
+    `SB_START_FUNC set_valid_mode(input integer value);
+        /* verilator lint_off IGNOREDRETURN */
+        aw_channel.set_valid_mode(value);
+        w_channel.set_valid_mode(value);
+        ar_channel.set_valid_mode(value);
+        /* verilator lint_on IGNOREDRETURN */
+    `SB_END_FUNC
+
+    `SB_START_FUNC set_ready_mode(input integer value);
+        /* verilator lint_off IGNOREDRETURN */
+        b_channel.set_ready_mode(value);
+        r_channel.set_ready_mode(value);
+        /* verilator lint_on IGNOREDRETURN */
+    `SB_END_FUNC
+
+    // clean up macros
+
+    `undef SB_START_FUNC
+    `undef SB_END_FUNC
+
+endmodule
+
+`default_nettype wire

--- a/switchboard/verilog/sim/sb_axi_m.sv
+++ b/switchboard/verilog/sim/sb_axi_m.sv
@@ -58,47 +58,39 @@ module sb_axi_m #(
 
     queue_to_sb_sim #(
         .VALID_MODE_DEFAULT(VALID_MODE_DEFAULT),
-        .DW(ADDR_WIDTH + 3)
+        .DW(ADDR_WIDTH + 3 + ID_WIDTH + 8 + 3 + 2 + 1 + 4)
     ) aw_channel (
         .clk(clk),
-        .data({m_axi_awprot, m_axi_awaddr}),
+        .data({m_axi_awcache, m_axi_awlock, m_axi_awburst, m_axi_awsize,
+            m_axi_awlen, m_axi_awid, m_axi_awprot, m_axi_awaddr}),
         .dest(),
         .last(),
         .valid(m_axi_awvalid),
         .ready(m_axi_awready)
     );
 
-    assign m_axi_awid = 0;
-    assign m_axi_awlen = 0;
-    assign m_axi_awsize = 0;
-    assign m_axi_awburst = 0;
-    assign m_axi_awlock = 0;
-    assign m_axi_awcache = 0;
-
     // W channel
 
     queue_to_sb_sim #(
         .VALID_MODE_DEFAULT(VALID_MODE_DEFAULT),
-        .DW(DATA_WIDTH + STRB_WIDTH)
+        .DW(DATA_WIDTH + STRB_WIDTH + 1)
     ) w_channel (
         .clk(clk),
-        .data({m_axi_wstrb, m_axi_wdata}),
+        .data({m_axi_wlast, m_axi_wstrb, m_axi_wdata}),
         .dest(),
         .last(),
         .valid(m_axi_wvalid),
         .ready(m_axi_wready)
     );
 
-    assign m_axi_wlast = 0;
-
     // B channel
 
     sb_to_queue_sim #(
         .READY_MODE_DEFAULT(READY_MODE_DEFAULT),
-        .DW(2)
+        .DW(2 + ID_WIDTH)
     ) b_channel (
         .clk(clk),
-        .data(m_axi_bresp),
+        .data({m_axi_bid, m_axi_bresp}),
         .dest(),
         .last(),
         .valid(m_axi_bvalid),
@@ -109,31 +101,25 @@ module sb_axi_m #(
 
     queue_to_sb_sim #(
         .VALID_MODE_DEFAULT(VALID_MODE_DEFAULT),
-        .DW(ADDR_WIDTH + 3)
+        .DW(ADDR_WIDTH + 3 + ID_WIDTH + 8 + 3 + 2 + 1 + 4)
     ) ar_channel (
         .clk(clk),
-        .data({m_axi_arprot, m_axi_araddr}),
+        .data({m_axi_arcache, m_axi_arlock, m_axi_arburst, m_axi_arsize,
+            m_axi_arlen, m_axi_arid, m_axi_arprot, m_axi_araddr}),
         .dest(),
         .last(),
         .valid(m_axi_arvalid),
         .ready(m_axi_arready)
     );
 
-    assign m_axi_arid = 0;
-    assign m_axi_arlen = 0;
-    assign m_axi_arsize = 0;
-    assign m_axi_arburst = 0;
-    assign m_axi_arlock = 0;
-    assign m_axi_arcache = 0;
-
     // R channel
 
     sb_to_queue_sim #(
         .READY_MODE_DEFAULT(READY_MODE_DEFAULT),
-        .DW(DATA_WIDTH + 2)
+        .DW(DATA_WIDTH + 2 + ID_WIDTH + 1)
     ) r_channel (
         .clk(clk),
-        .data({m_axi_rresp, m_axi_rdata}),
+        .data({m_axi_rlast, m_axi_rid, m_axi_rresp, m_axi_rdata}),
         .dest(),
         .last(),
         .valid(m_axi_rvalid),


### PR DESCRIPTION
This PR adds a driver for the full AXI interface.  The main difference with respect to the AXI-Lite driver is burst support; `read()` and `write()` methods automatically use the largest bursts possible to minimize the number of transactions.  To disable bursting, set the optional `max_beats=1` argument when using those methods.  In theory, `max_beats=16` could be used for AXI3 compatibility, although I haven't tested this.

Integration works the same way as for AXI-Lite:

1. Instantiate a switchboard module that will act as an AXI manager.

```verilog
`SB_AXI_M(mod_name, signal_prefix, data_width, addr_width);
```

2. Use `init()` to connect to switchboard queues to this module.

```verilog
initial begin
    sb_axi_m_i.init("axi");
end
```

3. In a Python script, create a corresponding `AxiTxRx` object.  Note the new optional `id_width` argument.

```python
from switchboard import AxiTxRx

...

axi = AxiTxRx('axi', data_width=..., addr_width=..., id_width=...)
```

4. Use `AxiTxRx.write()` and `AxiTxRx.read()` methods to issue write and read transactions.

```python
axi.write(0x12, np.uint8(0x34))
value = axi.read(0x12, np.uint8)  # value will contain 0x34
```

**Implementation note:** AXI and AXI-Lite are currently implemented separately.  Will explore merging some of common code in a future PR.