### PR TITLE
Fix SWITCHBOARD_SIM_PORT

### DIFF
--- a/examples/umi_endpoint/test.py
+++ b/examples/umi_endpoint/test.py
@@ -15,7 +15,7 @@ def main():
     dut = build_testbench()
 
     # create queues
-    umi = UmiTxRx("to_rtl.q", "from_rtl.q", fresh=True)
+    umi = UmiTxRx("udev_req.q", "udev_resp.q", fresh=True)
 
     # launch the simulation
     dut.simulate()

--- a/examples/umi_endpoint/testbench.sv
+++ b/examples/umi_endpoint/testbench.sv
@@ -18,11 +18,7 @@ module testbench (
     parameter integer CW=32;
     parameter integer AW=64;
 
-    `SB_UMI_WIRES(udev_req, DW, CW, AW);
-    `QUEUE_TO_UMI_SIM(udev_req, DW, CW, AW, "to_rtl.q");
-
-    `SB_UMI_WIRES(udev_resp, DW, CW, AW);
-    `UMI_TO_QUEUE_SIM(udev_resp, DW, CW, AW, "from_rtl.q");
+    `SWITCHBOARD_SIM_PORT(udev, DW);
 
     reg nreset = 1'b0;
     wire [AW-1:0] loc_addr;

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@
 from setuptools import setup, find_packages
 from pybind11.setup_helpers import Pybind11Extension, build_ext
 
-__version__ = "0.2.4"
+__version__ = "0.2.5"
 
 #################################################################################
 # parse_reqs, long_desc from https://github.com/siliconcompiler/siliconcompiler #

--- a/switchboard/verilog/common/switchboard.vh
+++ b/switchboard/verilog/common/switchboard.vh
@@ -63,11 +63,11 @@
     .a``_data(b``_data),                                                                           \
     .a``_ready(b``_ready)
 
-`define SWITCHBOARD_SIM_PORT(prefix, dw)                                                           \
-    `SB_UMI_WIRES(prefix``_req, dw, 32, 64);                                                       \
-    `SB_UMI_WIRES(prefix``_resp, dw, 32, 64);                                                      \
-    `QUEUE_TO_UMI_SIM(prefix``_req, dw, 32, 64);                                                   \
-    `UMI_TO_QUEUE_SIM(prefix``_resp, dw, 32, 64)
+`define SWITCHBOARD_SIM_PORT(prefix, dw, cw=32, aw=64)                                             \
+    `SB_UMI_WIRES(prefix``_req, dw, cw, aw);                                                       \
+    `SB_UMI_WIRES(prefix``_resp, dw, cw, aw);                                                      \
+    `QUEUE_TO_UMI_SIM(prefix``_req, dw, cw, aw, `"prefix``_req.q`");                               \
+    `UMI_TO_QUEUE_SIM(prefix``_resp, dw, cw, aw, `"prefix``_resp.q`")
 
 `define SB_WIRES(signal, dw)                                                                       \
     wire [((dw)-1):0] signal``_data;                                                               \


### PR DESCRIPTION
Also adds optional `cw` and `aw` inputs to make the macro more general-purpose.