### PR TITLE
Fix automatic naming of queues for TCP connections with multiple destinations

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@
 from setuptools import setup, find_packages
 from pybind11.setup_helpers import Pybind11Extension, build_ext
 
-__version__ = "0.2.7"
+__version__ = "0.2.8"
 
 #################################################################################
 # parse_reqs, long_desc from https://github.com/siliconcompiler/siliconcompiler #

--- a/switchboard/network.py
+++ b/switchboard/network.py
@@ -99,7 +99,10 @@ class TcpIntf:
     @property
     def wire_name(self):
         if 'port' in self.kwargs:
-            return f'port_{self.kwargs["port"]}'
+            retval = f'port_{self.kwargs["port"]}'
+            if self.destination is not None:
+                retval += f'_{self.destination}'
+            return retval
 
 
 class SbInst:


### PR DESCRIPTION
Destination number should be included in queue name in this situation to avoid naming collisions.  Switchboard was catching the naming collision, but there wasn't a convenient way to solve the problem.