### PR TITLE
Update for NumPy 2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@
 from setuptools import setup, find_packages
 from pybind11.setup_helpers import Pybind11Extension, build_ext
 
-__version__ = "0.2.9"
+__version__ = "0.2.10"
 
 #################################################################################
 # parse_reqs, long_desc from https://github.com/siliconcompiler/siliconcompiler #

--- a/switchboard/axi.py
+++ b/switchboard/axi.py
@@ -194,7 +194,7 @@ class AxiTxRx:
                 raise ValueError('Can only write integer dtypes such as uint8, uint16, etc.'
                     f'  (got dtype "{data.dtype}")')
         elif isinstance(data, np.integer):
-            write_data = np.array(data, ndmin=1, copy=False)
+            write_data = np.array(data, ndmin=1)
         else:
             raise TypeError(f"Unknown data type: {type(data)}")
 

--- a/switchboard/axil.py
+++ b/switchboard/axil.py
@@ -145,7 +145,7 @@ class AxiLiteTxRx:
                 raise ValueError('Can only write integer dtypes such as uint8, uint16, etc.'
                     f'  (got dtype "{data.dtype}")')
         elif isinstance(data, np.integer):
-            write_data = np.array(data, ndmin=1, copy=False)
+            write_data = np.array(data, ndmin=1)
         else:
             raise TypeError(f"Unknown data type: {type(data)}")
 

--- a/switchboard/umi.py
+++ b/switchboard/umi.py
@@ -292,7 +292,7 @@ class UmiTxRx:
                 raise ValueError('Can only write integer dtypes such as uint8, uint16, etc.'
                     f'  (got dtype "{data.dtype}")')
         elif isinstance(data, np.integer):
-            write_data = np.array(data, ndmin=1, copy=False)
+            write_data = np.array(data, ndmin=1)
         else:
             raise TypeError(f"Unknown data type: {type(data)}")
 
@@ -534,10 +534,7 @@ class UmiTxRx:
 
         # format the data for sending
         if isinstance(data, np.integer):
-            # copy=False should be safe here, because the data will be
-            # copied over to the queue; the original data will never
-            # be read again or modified from the C++ side
-            atomic_data = np.array(data, ndmin=1, copy=False).view(np.uint8)
+            atomic_data = np.array(data, ndmin=1).view(np.uint8)
             result = self.umi.atomic(addr, atomic_data, opcode, srcaddr, qos, prot, error)
             return result.view(data.dtype)[0]
         else:


### PR DESCRIPTION
This PR fixes an issue that came about with the recent release of NumPy 2.0.  There were a few places where `np.array()` was used with `copy=False`, and that started causing exceptions because NumPy could not avoid making a copy.

To solve this, I simply removed `copy=False`.  The performance impact should be low, because the `copy=False` option only came into play when writing NumPy integers (not arrays) as a UMI or AXI/AXI-Lite payload.  Worst case, a few extra bytes will have to be copied for `write()` and `atomic()` operations, which should not be a bottleneck.  In fact, it's possible that those bytes were already being copied and not throwing an exception under NumPy 1.0 behavior.