### PR TITLE
Pin SiliconCompiler version to <0.24.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@
 
 numpy
 tqdm
-siliconcompiler
+siliconcompiler <0.24.0
 
 # Testing dependencies
 #:test

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@
 from setuptools import setup, find_packages
 from pybind11.setup_helpers import Pybind11Extension, build_ext
 
-__version__ = "0.2.10"
+__version__ = "0.2.11"
 
 #################################################################################
 # parse_reqs, long_desc from https://github.com/siliconcompiler/siliconcompiler #


### PR DESCRIPTION
Upcoming changes to SiliconCompiler will change the Chip API that switchboard depends on; goal of this PR is to prevent switchboard from breaking after those changes.  In a future PR, switchboard should be updated to be compatible with the new API.