### PR TITLE
fix wheel workflow permissions

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -70,6 +70,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published' && !contains(github.event.release.body, 'NOPUBLISH')
 
+    permissions:
+      contents: write
+
     steps:
     - uses: actions/download-artifact@v4
       with:


### PR DESCRIPTION
Github seems to be enforcing this permissions thing now, so a lot of our workflows that use the `softprops/action-gh-release` are failing.