### PR TITLE
switch to umi

### DIFF
--- a/examples/network-fifo-chain/test.py
+++ b/examples/network-fifo-chain/test.py
@@ -6,7 +6,7 @@
 # This code is licensed under Apache License 2.0 (see LICENSE for details)
 
 import os
-import umi
+from umi import sumi
 from copy import deepcopy
 
 from switchboard import SbNetwork, umi_loopback, TcpIntf
@@ -182,10 +182,7 @@ def make_umi_fifo(net):
     dut = net.make_dut('umi_fifo', parameters=parameters, interfaces=interfaces,
         clocks=clocks, resets=resets, tieoffs=tieoffs)
 
-    dut.use(umi)
-    dut.add('option', 'library', 'umi')
-    dut.add('option', 'library', 'lambdalib_auxlib')
-    dut.add('option', 'library', 'lambdalib_ramlib')
+    dut.use(sumi)
 
     dut.input('umi/rtl/umi_fifo.v', package='umi')
 

--- a/examples/network-fifo-chain/test.py
+++ b/examples/network-fifo-chain/test.py
@@ -184,7 +184,7 @@ def make_umi_fifo(net):
 
     dut.use(sumi)
 
-    dut.input('umi/rtl/umi_fifo.v', package='umi')
+    dut.input('sumi/rtl/umi_fifo.v', package='umi')
 
     return dut
 

--- a/examples/network/test.py
+++ b/examples/network/test.py
@@ -108,7 +108,7 @@ def make_umi_fifo(net):
 
     dut.use(sumi)
 
-    dut.input('umi/rtl/umi_fifo.v', package='umi')
+    dut.input('sumi/rtl/umi_fifo.v', package='umi')
 
     return dut
 

--- a/examples/network/test.py
+++ b/examples/network/test.py
@@ -7,7 +7,7 @@
 
 import numpy as np
 
-import umi
+from umi import sumi
 from switchboard import SbNetwork
 
 from pathlib import Path
@@ -106,10 +106,7 @@ def make_umi_fifo(net):
     dut = net.make_dut('umi_fifo', parameters=parameters, interfaces=interfaces,
         clocks=clocks, resets=resets, tieoffs=tieoffs)
 
-    dut.use(umi)
-    dut.add('option', 'library', 'umi')
-    dut.add('option', 'library', 'lambdalib_auxlib')
-    dut.add('option', 'library', 'lambdalib_ramlib')
+    dut.use(sumi)
 
     dut.input('umi/rtl/umi_fifo.v', package='umi')
 
@@ -170,10 +167,7 @@ def make_umi2axil(net):
     dut = net.make_dut('umi2axilite', parameters=parameters,
         interfaces=interfaces, resets=resets)
 
-    dut.use(umi)
-    dut.add('option', 'library', 'umi')
-    dut.add('option', 'library', 'lambdalib_auxlib')
-    dut.add('option', 'library', 'lambdalib_ramlib')
+    dut.use(sumi)
 
     dut.input('utils/rtl/umi2axilite.v', package='umi')
 

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -1,2 +1,2 @@
 # Examples dependencies
-umi-hw >= 0.1.0, < 0.2.0
+umi >= 0.1.0, < 0.2.0

--- a/examples/tcp/fifos/fifos.py
+++ b/examples/tcp/fifos/fifos.py
@@ -7,7 +7,7 @@ import os
 import sys
 import signal
 
-import umi
+from umi import sumi
 from switchboard import SbNetwork, TcpIntf, flip_intf
 
 
@@ -107,10 +107,7 @@ def make_umi_fifo(net, dw, aw, cw):
     dut = net.make_dut('umi_fifo', parameters=parameters, interfaces=interfaces,
         clocks=clocks, resets=resets, tieoffs=tieoffs)
 
-    dut.use(umi)
-    dut.add('option', 'library', 'umi')
-    dut.add('option', 'library', 'lambdalib_auxlib')
-    dut.add('option', 'library', 'lambdalib_ramlib')
+    dut.use(sumi)
 
     dut.input('umi/rtl/umi_fifo.v', package='umi')
 

--- a/examples/tcp/fifos/fifos.py
+++ b/examples/tcp/fifos/fifos.py
@@ -109,7 +109,7 @@ def make_umi_fifo(net, dw, aw, cw):
 
     dut.use(sumi)
 
-    dut.input('umi/rtl/umi_fifo.v', package='umi')
+    dut.input('sumi/rtl/umi_fifo.v', package='umi')
 
     return dut
 

--- a/examples/tcp/ram/ram.py
+++ b/examples/tcp/ram/ram.py
@@ -7,7 +7,7 @@ import os
 import sys
 import signal
 
-import umi
+from umi import sumi
 from switchboard import SbNetwork, TcpIntf
 
 from pathlib import Path
@@ -73,8 +73,7 @@ def make_umiram(net):
 
     dut = net.make_dut('umiram', parameters=parameters, interfaces=interfaces)
 
-    dut.use(umi)
-    dut.add('option', 'library', 'umi')
+    dut.use(sumi)
 
     dut.input(THIS_DIR.parent.parent / 'common' / 'verilog' / 'umiram.sv', package='umi')
 

--- a/examples/umi_endpoint/test.py
+++ b/examples/umi_endpoint/test.py
@@ -7,7 +7,7 @@
 
 import numpy as np
 from switchboard import UmiTxRx, SbDut
-import umi
+from umi import sumi
 
 
 def main():
@@ -79,9 +79,7 @@ def build_testbench():
 
     dut.input('testbench.sv')
 
-    dut.use(umi)
-    dut.add('option', 'library', 'umi')
-    dut.add('option', 'library', 'lambdalib_auxlib')
+    dut.use(sumi)
 
     dut.build()
 

--- a/examples/umi_fifo/test.py
+++ b/examples/umi_fifo/test.py
@@ -6,7 +6,7 @@
 # This code is licensed under Apache License 2.0 (see LICENSE for details)
 
 from switchboard import random_umi_packet, SbDut
-import umi
+from umi import sumi
 
 
 def main():
@@ -87,10 +87,7 @@ def build_testbench():
         parameters=parameters, interfaces=interfaces, clocks=clocks, resets=resets,
         tieoffs=tieoffs)
 
-    dut.use(umi)
-    dut.add('option', 'library', 'umi')
-    dut.add('option', 'library', 'lambdalib_auxlib')
-    dut.add('option', 'library', 'lambdalib_ramlib')
+    dut.use(sumi)
 
     dut.build()
 

--- a/examples/umi_fifo_flex/test.py
+++ b/examples/umi_fifo_flex/test.py
@@ -6,7 +6,7 @@
 # This code is licensed under Apache License 2.0 (see LICENSE for details)
 
 from switchboard import SbDut, umi_loopback
-import umi
+from umi import sumi
 
 
 def main():
@@ -67,10 +67,7 @@ def build_testbench():
         parameters=parameters, interfaces=interfaces, clocks=clocks, resets=resets,
         tieoffs=tieoffs)
 
-    dut.use(umi)
-    dut.add('option', 'library', 'umi')
-    dut.add('option', 'library', 'lambdalib_auxlib')
-    dut.add('option', 'library', 'lambdalib_ramlib')
+    dut.use(sumi)
 
     dut.build()
 

--- a/examples/umi_gpio/test.py
+++ b/examples/umi_gpio/test.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2024 Zero ASIC Corporation
 # This code is licensed under Apache License 2.0 (see LICENSE for details)
 
-import umi
+from umi import sumi
 import random
 from switchboard import SbNetwork, sb_path
 
@@ -143,8 +143,7 @@ def make_umi_gpio(net, owidth, iwidth):
 
     block = net.make_dut('umi_gpio', parameters=parameters, interfaces=interfaces, resets=resets)
 
-    block.use(umi)
-    block.add('option', 'library', 'umi')
+    block.use(sumi)
 
     block.input(sb_path() / 'verilog' / 'common' / 'umi_gpio.v')
 

--- a/examples/umi_splitter/test.py
+++ b/examples/umi_splitter/test.py
@@ -6,7 +6,7 @@
 # This code is licensed under Apache License 2.0 (see LICENSE for details)
 
 from switchboard import SbDut, random_umi_packet
-import umi
+from umi import sumi
 
 
 def main():
@@ -78,10 +78,7 @@ def build_testbench():
     dut = SbDut('umi_splitter', autowrap=True, cmdline=True, extra_args=extra_args,
         interfaces=interfaces, clocks=[])
 
-    dut.use(umi)
-    dut.add('option', 'library', 'umi')
-    dut.add('option', 'library', 'lambdalib_auxlib')
-    dut.add('option', 'library', 'lambdalib_ramlib')
+    dut.use(sumi)
 
     dut.build()
 

--- a/examples/umiparam-network/test.py
+++ b/examples/umiparam-network/test.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2024 Zero ASIC Corporation
 # This code is licensed under Apache License 2.0 (see LICENSE for details)
 
-import umi
+from umi import sumi
 import numpy as np
 
 from copy import deepcopy
@@ -112,10 +112,7 @@ def make_umiparam(net):
 
     dut = net.make_dut('umiparam', parameters=parameters, interfaces=interfaces, resets=resets)
 
-    dut.use(umi)
-    dut.add('option', 'library', 'umi')
-    dut.add('option', 'library', 'lambdalib_auxlib')
-    dut.add('option', 'library', 'lambdalib_ramlib')
+    dut.use(sumi)
 
     dut.set('option', 'idir', sb_path() / 'verilog' / 'common')
 

--- a/examples/umiparam/test.py
+++ b/examples/umiparam/test.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2024 Zero ASIC Corporation
 # This code is licensed under Apache License 2.0 (see LICENSE for details)
 
-import umi
+from umi import sumi
 import numpy as np
 
 from switchboard import SbDut
@@ -47,10 +47,7 @@ def build_testbench():
     dut = SbDut('umiparam', cmdline=True, autowrap=True, parameters=parameters,
         interfaces=interfaces, resets=resets)
 
-    dut.use(umi)
-    dut.add('option', 'library', 'umi')
-    dut.add('option', 'library', 'lambdalib_auxlib')
-    dut.add('option', 'library', 'lambdalib_ramlib')
+    dut.use(sumi)
 
     dut.input('../common/verilog/umiparam.sv')
 

--- a/examples/umiram/test.py
+++ b/examples/umiram/test.py
@@ -10,7 +10,7 @@
 import numpy as np
 from pathlib import Path
 from switchboard import SbDut, UmiTxRx, binary_run
-import umi
+from umi import sumi
 
 THIS_DIR = Path(__file__).resolve().parent
 
@@ -94,8 +94,7 @@ def build_testbench():
     dut.input('testbench.sv')
     dut.input(THIS_DIR.parent / 'common' / 'verilog' / 'umiram.sv')
 
-    dut.use(umi)
-    dut.add('option', 'library', 'umi')
+    dut.use(sumi)
 
     dut.build()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@
 
 numpy
 tqdm
-siliconcompiler >= 0.25.0, < 0.27.0
+siliconcompiler >= 0.26.0, < 0.27.0
 
 # Testing dependencies
 #:test


### PR DESCRIPTION
switch from umi-hw to umi package in testing
make use of SC 0.26 auto_enable capability

no need for a new release of SB as this is just modifying examples.