### PR TITLE
Refuse PyUmiPacket merge when the LEN field would overflow

### DIFF
--- a/examples/test_umi_packet_merge.py
+++ b/examples/test_umi_packet_merge.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2024 Zero ASIC Corporation
+# This code is licensed under Apache License 2.0 (see LICENSE for details)
+
+import numpy as np
+from switchboard import PyUmiPacket, UmiCmd, umi_pack, umi_len, umi_eom
+
+# SIZE=0 means one byte per word, so LEN+1 is also the number of data bytes
+SIZE = 0
+
+
+def make_packet(len_field, dstaddr, srcaddr, eom=0):
+    cmd = umi_pack(UmiCmd.UMI_REQ_WRITE, 0, SIZE, len_field, eom, 0)
+    data = np.arange(len_field + 1, dtype=np.uint8)
+    return PyUmiPacket(cmd, dstaddr, srcaddr, data)
+
+
+def test_merge_within_len_limit():
+    # 255 words + 1 word fills the LEN field exactly, so this merge is allowed
+    p = make_packet(254, 0, 0)
+    q = make_packet(0, 255, 255, eom=1)
+
+    assert p.merge(q)
+
+    assert umi_len(p.cmd) == 255
+    assert umi_eom(p.cmd) == 1
+    assert p.data.size == 256
+    assert p.data[255] == q.data[0]
+
+
+def test_merge_beyond_len_limit_rejected():
+    # 255 words + 6 words needs a LEN of 260, which does not fit in the
+    # eight-bit LEN field, so the merge must be refused rather than wrapping
+    p = make_packet(254, 0, 0)
+    q = make_packet(5, 255, 255, eom=1)
+
+    cmd_before = p.cmd
+
+    assert not p.merge(q)
+
+    # the rejected merge must leave the packet untouched
+    assert p.cmd == cmd_before
+    assert umi_len(p.cmd) == 254
+    assert umi_eom(p.cmd) == 0
+    assert p.data.size == 255
+
+
+def test_merge_ordinary_packets():
+    p = make_packet(3, 0, 0)
+    q = make_packet(1, 4, 4, eom=1)
+
+    assert p.merge(q)
+
+    assert umi_len(p.cmd) == 5
+    assert umi_eom(p.cmd) == 1
+    assert np.array_equal(p.data, np.array([0, 1, 2, 3, 0, 1], dtype=np.uint8))
+
+
+if __name__ == '__main__':
+    test_merge_within_len_limit()
+    test_merge_beyond_len_limit_rejected()
+    test_merge_ordinary_packets()

--- a/python/switchboard_pybind.cc
+++ b/python/switchboard_pybind.cc
@@ -199,6 +199,12 @@ struct PyUmiPacket {
         uint32_t len = umi_len(cmd);
         uint32_t nbytes = (len + 1) << size;
 
+        if ((len + umi_len(other.cmd) + 1) > UMI_MAX_LEN) {
+            // LEN is an eight-bit field, so the merged packet could not
+            // represent its own length; merging would silently wrap around
+            return false;
+        }
+
         if (other.dstaddr != (dstaddr + nbytes)) {
             // new dstaddr must be next sequentially
             return false;

--- a/switchboard/cpp/umilib.h
+++ b/switchboard/cpp/umilib.h
@@ -130,6 +130,11 @@ static inline uint32_t umi_len(uint32_t cmd) {
     }
 }
 DECL_UMI_SETTER(len, 8, 8)
+
+// largest value that the eight-bit LEN field can hold, corresponding to
+// (UMI_MAX_LEN + 1) words of data in a single transaction
+#define UMI_MAX_LEN 255
+
 DECL_UMI_FIELD(atype, 8, 8)
 DECL_UMI_FIELD(qos, 16, 4)
 DECL_UMI_FIELD(prot, 20, 2)


### PR DESCRIPTION
This PR proposes refusing a `PyUmiPacket` merge when the combined LEN would overflow the eight-bit LEN field, fixes #262. We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/400. You can sign in with your GitHub ID to claim ownership of the project.

## What goes wrong today

`PyUmiPacket::merge` writes the merged length back with `set_umi_len(&cmd, len + umi_len(other.cmd) + 1)`. LEN is an eight-bit field (`DECL_UMI_SETTER(len, 8, 8)` in `switchboard/cpp/umilib.h`) and `set_umi_bits` masks the value to that width, so a merge whose combined length exceeds 256 words wraps around silently and still returns `true`. By that point the packet has already been resized and the incoming data copied in, so the caller is handed a transaction whose command describes far less data than the packet actually holds.

Reproducing on `main` at 4287d19 — `pip install .[test]`, then:

```python
import numpy as np
from switchboard import PyUmiPacket, UmiCmd, umi_pack, umi_len

def make(len_field, addr):
    cmd = umi_pack(UmiCmd.UMI_REQ_WRITE, 0, 0, len_field, 0, 0)
    return PyUmiPacket(cmd, addr, addr, np.arange(len_field + 1, dtype=np.uint8))

p = make(254, 0)    # LEN=254, i.e. 255 words
q = make(5, 255)    # LEN=5,   i.e. 6 words

print('merge returned:', p.merge(q))
print('LEN after merge:', umi_len(p.cmd), '->', umi_len(p.cmd) + 1, 'words')
print('bytes actually held:', p.data.size)
```

Output on `main`:

```
merge returned: True
LEN after merge: 4 -> 5 words
bytes actually held: 261
```

That is the case @azaidy described in #262: (254 + 1) + (5 + 1) rolls back to a LEN of 4, and the merge reports success.

## The change

`merge` now returns `false` when `len + umi_len(other.cmd) + 1` would exceed the largest value LEN can represent, and it checks this before `resize`, so a refused merge leaves the packet untouched instead of half-modified. The limit is named `UMI_MAX_LEN` in `switchboard/cpp/umilib.h`, beside the LEN accessors it belongs with.

Nothing that could legitimately merge before stops merging: 256 words is the most a single UMI transaction can describe, so the only merges now refused are the ones that were producing incorrect packets. `umi_loopback` already treats a `false` return as "start a new transaction", and it applies the same rule on the TX and the RX side, so a stream that crosses the limit is split at the same point on both — I checked that a 512-word stream partitions identically either way.

## Verification

Same script, with the change applied:

```
merge returned: False
LEN after merge: 254 -> 255 words
bytes actually held: 255
```

`examples/test_umi_packet_merge.py` adds three cases in the style of `examples/test_bit_vector.py`: the boundary merge that fills LEN exactly (LEN 254 plus LEN 0, giving LEN 255) still succeeds, the overflowing merge is refused and leaves the packet unchanged, and an ordinary short merge still concatenates its data as before. Run against an unpatched build, the middle case fails on `assert not p.merge(q)` while the other two pass, so the test is red without the change and green with it.

I ran `pytest` in `examples/` before and after the change and got the same set of failures both times — the ten `test_make` cases, which need Verilator or Icarus and the `umi` package, none of which I have locally — with the three new cases passing on top. `make` in `tests/` prints `PASS` with the modified header, including `torture.c`, which compiles it as C rather than C++. `flake8` is clean.

## How this was managed

This work was tracked as [Fix merging of PyUmiPacket](https://eastagiletracker.com/projects/400/stories/330171) on a board at https://eastagiletracker.com/projects/400 that was built from this repository's own issues and pull requests, 315 stories in all.

![board](https://raw.githubusercontent.com/eastagiletracker/switchboard/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
